### PR TITLE
Only add b64_content if content_uri is available

### DIFF
--- a/app/models/ethscription.rb
+++ b/app/models/ethscription.rb
@@ -133,7 +133,10 @@ class Ethscription < ApplicationRecord
         json['attachment_path'] = Rails.application.routes.url_helpers.attachment_ethscription_path(id: transaction_hash)
       end
 
-      json['b64_content'] = Base64.strict_encode64(content.to_s)
+      # Only add b64_content if content_uri is available (not the case with transaction_hash_only queries)
+      if attributes.key?('content_uri')
+        json['b64_content'] = Base64.strict_encode64(content.to_s)
+      end
     end
   end
   

--- a/app/models/ethscription.rb
+++ b/app/models/ethscription.rb
@@ -134,7 +134,7 @@ class Ethscription < ApplicationRecord
       end
 
       # Only add b64_content if content_uri is available (not the case with transaction_hash_only queries)
-      if attributes.key?('content_uri')
+      if has_attribute?(:content_uri)
         json['b64_content'] = Base64.strict_encode64(content.to_s)
       end
     end


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Only include `b64_content` in `Ethscription.as_json` when the `content_uri` attribute is present.
> 
> - **Model (`app/models/ethscription.rb`)**:
>   - Update `as_json`: add `b64_content` only if `has_attribute?(:content_uri)`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 51bd293c506dbf4090842471a4a86b0701e5ffca. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->