### PR TITLE
Main into Sepolia

### DIFF
--- a/app/models/ethscription.rb
+++ b/app/models/ethscription.rb
@@ -133,7 +133,10 @@ class Ethscription < ApplicationRecord
         json['attachment_path'] = Rails.application.routes.url_helpers.attachment_ethscription_path(id: transaction_hash)
       end
 
-      json['b64_content'] = Base64.strict_encode64(content.to_s)
+      # Only add b64_content if content_uri is available (not the case with transaction_hash_only queries)
+      if attributes.key?('content_uri')
+        json['b64_content'] = Base64.strict_encode64(content.to_s)
+      end
     end
   end
   

--- a/app/models/ethscription.rb
+++ b/app/models/ethscription.rb
@@ -133,7 +133,7 @@ class Ethscription < ApplicationRecord
         json['attachment_path'] = Rails.application.routes.url_helpers.attachment_ethscription_path(id: transaction_hash)
       end
 
-      json['b64_content'] = Base64.strict_encode64(content)
+      json['b64_content'] = Base64.strict_encode64(content.to_s)
     end
   end
   

--- a/app/models/ethscription.rb
+++ b/app/models/ethscription.rb
@@ -128,10 +128,12 @@ class Ethscription < ApplicationRecord
       if options[:include_latest_transfer]
         json[:latest_transfer] = latest_transfer.as_json
       end
-      
+
       if json['attachment_sha']
         json['attachment_path'] = Rails.application.routes.url_helpers.attachment_ethscription_path(id: transaction_hash)
       end
+
+      json['b64_content'] = Base64.strict_encode64(content)
     end
   end
   

--- a/app/models/ethscription.rb
+++ b/app/models/ethscription.rb
@@ -134,7 +134,7 @@ class Ethscription < ApplicationRecord
       end
 
       # Only add b64_content if content_uri is available (not the case with transaction_hash_only queries)
-      if attributes.key?('content_uri')
+      if has_attribute?(:content_uri)
         json['b64_content'] = Base64.strict_encode64(content.to_s)
       end
     end


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds `b64_content` (Base64-encoded `content`) to `Ethscription#as_json` when `content_uri` is present, preserving existing `attachment_path` behavior.
> 
> - **Model (`app/models/ethscription.rb`)**:
>   - **as_json**:
>     - Add `b64_content` (Base64-encoded `content`) when `content_uri` attribute is available (skips for transaction_hash_only queries).
>     - Retain `attachment_path` population when `attachment_sha` is present.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bc5a15aa4c000595eca8c037b6d66ba4dd65f29a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->