### PR TITLE
Improve prefetcher

### DIFF
--- a/app/services/eth_block_importer.rb
+++ b/app/services/eth_block_importer.rb
@@ -329,9 +329,14 @@ class EthBlockImporter
     start = Time.current
 
     # Fetch block data from prefetcher
-    ImportProfiler.start("prefetch_fetch")
-    response = @prefetcher.fetch(block_number)
-    ImportProfiler.stop("prefetch_fetch")
+    begin
+      ImportProfiler.start('prefetcher_fetch')
+      response = prefetcher.fetch(block_number)
+    rescue L1RpcPrefetcher::BlockFetchError => e
+      raise BlockNotReadyToImportError.new(e.message)
+    ensure
+      ImportProfiler.stop('prefetcher_fetch')
+    end
 
     # Handle cancellation, fetch failure, or block not ready
     if response.nil?


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Enhances L1 prefetcher fetch semantics, chain-tip caching, and shutdown, updates importer to handle new errors, and hardens the clockwork loop with cleaner shutdown and reorg handling.
> 
> - **Prefetcher (`lib/l1_rpc_prefetcher.rb`)**:
>   - Add `BlockFetchError` and raise on nil/not-ready results; use `:not_ready_sentinel`.
>   - Dynamic chain-tip strategy with memoized `cached_l1_block_number` and `@last_chain_tip`; lower `ahead` default to `20`.
>   - Improve `shutdown`: short timeout, cancel pending promises, clear state, and structured logging; return boolean.
>   - Simplify `fetch`: delete failed promises; keep timeout behavior via `value!` exceptions.
> - **Importer (`app/services/eth_block_importer.rb`)**:
>   - Wrap prefetch call with profiling (`prefetcher_fetch`) and map `L1RpcPrefetcher::BlockFetchError` to `BlockNotReadyToImportError`.
> - **Runner (`config/derive_ethscriptions_blocks.rb`)**:
>   - Remove signal traps; wrap loop in `begin...ensure` to `shutdown` importer.
>   - On reorg, explicitly `shutdown` then reinitialize importer; add concise wait/retry logging and sleep placement.
>   - Cleanup minor counters/flow; keep session summaries and validation reporting.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b260fa97ca01c2175b550c2eb129726a2d39900f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->