### PR TITLE
Predeploys should be proxies

### DIFF
--- a/contracts/src/CollectionsManager.sol
+++ b/contracts/src/CollectionsManager.sol
@@ -96,7 +96,7 @@ contract CollectionsManager is IProtocolHandler {
         // Note: Similar to ItemData but without ethscriptionId (can't change)
     }
 
-    address public constant erc721Template = Predeploys.ERC721_TEMPLATE;
+    address public constant erc721Template = Predeploys.ERC721_TEMPLATE_IMPLEMENTATION;
     address public constant ethscriptions = Predeploys.ETHSCRIPTIONS;
 
     // Track deployed collections by ID

--- a/contracts/src/TokenManager.sol
+++ b/contracts/src/TokenManager.sol
@@ -40,7 +40,7 @@ contract TokenManager is IProtocolHandler {
         uint256 amount;
     }
 
-    address public constant erc20Template = Predeploys.ERC20_TEMPLATE;
+    address public constant erc20Template = Predeploys.ERC20_TEMPLATE_IMPLEMENTATION;
     address public constant ethscriptions = Predeploys.ETHSCRIPTIONS;
     
     // Track deployed tokens by protocol+tick for find-or-create

--- a/contracts/src/libraries/Predeploys.sol
+++ b/contracts/src/libraries/Predeploys.sol
@@ -19,31 +19,48 @@ library Predeploys {
     address constant PROXY_ADMIN = 0x4200000000000000000000000000000000000018;
     
     // ============ Ethscriptions System Predeploys ============
-    // Using 0xee namespace for Ethscriptions contracts
+    // Using 0x3300… namespace for Ethscriptions contracts
     
     /// @notice Ethscriptions NFT contract
-    address constant ETHSCRIPTIONS = 0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE;
+    /// @dev Moved to the 0x3300… namespace to align with other Ethscriptions predeploys
+    address constant ETHSCRIPTIONS = 0x3300000000000000000000000000000000000001;
     
     /// @notice TokenManager for ERC20 token creation
     address constant TOKEN_MANAGER = 0x3300000000000000000000000000000000000002;
     
     /// @notice EthscriptionsProver for L1 provability
     address constant ETHSCRIPTIONS_PROVER = 0x3300000000000000000000000000000000000003;
-    
-    /// @notice EthscriptionsERC20 template for cloning
-    address constant ERC20_TEMPLATE = 0x3300000000000000000000000000000000000004;
 
-    /// @notice EthscriptionERC721 template for cloning (collections)
-    address constant ERC721_TEMPLATE = 0x3300000000000000000000000000000000000005;
+    /// @notice Proxy address reserved for the ERC20 template (blank proxy)
+    address constant ERC20_TEMPLATE_PROXY = 0x3300000000000000000000000000000000000004;
+
+    /// @notice Implementation address for the ERC20 template (actual logic contract)
+    address constant ERC20_TEMPLATE_IMPLEMENTATION = 0xc0D3c0D3c0D3c0d3c0d3C0d3C0d3c0D3C0D30004;
+
+    /// @notice Proxy address reserved for the ERC721 template (blank proxy)
+    address constant ERC721_TEMPLATE_PROXY = 0x3300000000000000000000000000000000000005;
+
+    /// @notice Implementation address for the ERC721 template (actual logic contract)
+    address constant ERC721_TEMPLATE_IMPLEMENTATION = 0xc0d3C0d3c0D3c0d3C0D3C0D3c0D3C0D3c0d30005;
 
     /// @notice CollectionsManager for collections protocol
     address constant COLLECTIONS_MANAGER = 0x3300000000000000000000000000000000000006;
     
     // ============ Helper Functions ============
     
-    /// @notice Returns true if the address is a predeploy
-    function isPredeployNamespace(address _addr) internal pure returns (bool) {
+    /// @notice Returns true if the address is an OP Stack predeploy (0x4200… namespace)
+    function isOPPredeployNamespace(address _addr) internal pure returns (bool) {
         return uint160(_addr) >> 11 == uint160(0x4200000000000000000000000000000000000000) >> 11;
+    }
+
+    /// @notice Returns true if the address is an Ethscriptions predeploy (0x3300… namespace)
+    function isEthscriptionsPredeployNamespace(address _addr) internal pure returns (bool) {
+        return uint160(_addr) >> 11 == uint160(0x3300000000000000000000000000000000000000) >> 11;
+    }
+
+    /// @notice Returns true if the address is a recognized predeploy (OP or Ethscriptions)
+    function isPredeployNamespace(address _addr) internal pure returns (bool) {
+        return isOPPredeployNamespace(_addr) || isEthscriptionsPredeployNamespace(_addr);
     }
     
     /// @notice Converts a predeploy address to its code namespace equivalent

--- a/lib/event_decoder.rb
+++ b/lib/event_decoder.rb
@@ -16,7 +16,7 @@ class EventDecoder
     'Transfer(address,address,uint256)'
   ).unpack1('H*')
 
-  ETHSCRIPTIONS_ADDRESS = '0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE'
+  ETHSCRIPTIONS_ADDRESS = SysConfig::ETHSCRIPTIONS_ADDRESS.to_hex
 
   class << self
     def decode_receipt_logs(receipt)

--- a/lib/storage_reader.rb
+++ b/lib/storage_reader.rb
@@ -1,5 +1,5 @@
 class StorageReader
-  ETHSCRIPTIONS_ADDRESS = '0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE'
+  ETHSCRIPTIONS_ADDRESS = SysConfig::ETHSCRIPTIONS_ADDRESS.to_hex
 
   # Define the nested ContentInfo struct
   CONTENT_INFO_STRUCT = {

--- a/lib/sys_config.rb
+++ b/lib/sys_config.rb
@@ -8,7 +8,7 @@ module SysConfig
   # System addresses (matching Solidity contracts)
   SYSTEM_ADDRESS = Address20.from_hex("0xdeaddeaddeaddeaddeaddeaddeaddeaddead0001")
   L1_INFO_ADDRESS = Address20.from_hex("0x4200000000000000000000000000000000000015")
-  ETHSCRIPTIONS_ADDRESS = Address20.from_hex("0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE")
+  ETHSCRIPTIONS_ADDRESS = Address20.from_hex("0x3300000000000000000000000000000000000001")
   TOKEN_MANAGER_ADDRESS = Address20.from_hex("0x3300000000000000000000000000000000000002")
   
   # Deposit transaction domains


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Moves Ethscriptions to proxied 0x330… predeploys, wires implementations via code-namespace, and updates template/constants and tooling accordingly.
> 
> - **Genesis/Predeploy Setup**:
>   - Switch Ethscriptions to proxied predeploys across `0x3300…` with EIP-1967 admin set to `Predeploys.PROXY_ADMIN` and implementations in code-namespace via `setImplementation`.
>   - Create genesis Ethscriptions by etching `GenesisEthscriptions` to the implementation address, calling via proxy, then swapping in real `Ethscriptions` implementation without resetting nonce.
>   - Add `_setImplementationCodeNamed` and `_setCodeAt` helpers; templates (`ERC20`, `ERC721`) etched at implementation addresses (not proxied).
> - **Predeploys Library**:
>   - Update `ETHSCRIPTIONS` to `0x3300…0001`; add `ERC20_TEMPLATE_PROXY/IMPLEMENTATION` and `ERC721_TEMPLATE_PROXY/IMPLEMENTATION` constants.
>   - Introduce `isOPPredeployNamespace`, `isEthscriptionsPredeployNamespace`, and broaden `isPredeployNamespace`; keep `predeployToCodeNamespace` for both namespaces.
> - **Contracts**:
>   - `CollectionsManager` and `TokenManager`: point `erc721Template`/`erc20Template` to `*_TEMPLATE_IMPLEMENTATION` constants.
> - **Ruby Tooling**:
>   - `SysConfig`: set `ETHSCRIPTIONS_ADDRESS` to `0x3300…0001`.
>   - `event_decoder.rb` and `storage_reader.rb`: use `SysConfig::ETHSCRIPTIONS_ADDRESS` instead of hardcoded address.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 232e5391f6f48041bcdeb29ccc65104ca8f9e600. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->