### PR TITLE
Refactor contracts

### DIFF
--- a/contracts/script/L2Genesis.s.sol
+++ b/contracts/script/L2Genesis.s.sol
@@ -32,15 +32,15 @@ contract GenesisEthscriptions is Ethscriptions {
         require(ethscriptions[params.transactionHash].creator == address(0), "Ethscription already exists");
 
         // Check protocol uniqueness using content URI hash
-        if (contentUriExists[params.contentUriHash]) {
+        if (firstEthscriptionByContentUri[params.contentUriHash] != bytes32(0)) {
             if (!params.esip6) revert DuplicateContentUri();
         }
 
         // Store content and get content SHA (reusing parent's helper)
         bytes32 contentSha = _storeContent(params.content);
 
-        // Mark content URI as used
-        contentUriExists[params.contentUriHash] = true;
+        // Mark content URI as used by storing this ethscription's tx hash
+        firstEthscriptionByContentUri[params.contentUriHash] = params.transactionHash;
 
         // Set all values including genesis-specific ones
         ethscriptions[params.transactionHash] = Ethscription({
@@ -341,7 +341,7 @@ contract L2Genesis is Script {
         params.mimeSubtype = vm.parseJsonString(json, string.concat(basePath, ".mime_subtype"));
         params.esip6 = vm.parseJsonBool(json, string.concat(basePath, ".esip6"));
         params.protocolParams = Ethscriptions.ProtocolParams({
-            protocol: "",
+            protocolName: "",
             operation: "",
             data: ""
         });

--- a/contracts/src/Ethscriptions.sol
+++ b/contracts/src/Ethscriptions.sol
@@ -2,26 +2,27 @@
 pragma solidity 0.8.24;
 
 import "./ERC721EthscriptionsUpgradeable.sol";
-import {SSTORE2} from "solady/utils/SSTORE2.sol";
-import {Base64} from "solady/utils/Base64.sol";
 import {LibString} from "solady/utils/LibString.sol";
+import "./libraries/SSTORE2ChunkedStorageLib.sol";
+import "./libraries/EthscriptionsRendererLib.sol";
 import "./EthscriptionsProver.sol";
 import "./libraries/Predeploys.sol";
 import "./L2/L1Block.sol";
 import "./interfaces/IProtocolHandler.sol";
+import "./libraries/Constants.sol";
 
 /// @title Ethscriptions ERC-721 Contract
 /// @notice Mints Ethscriptions as ERC-721 tokens based on L1 transaction data
 /// @dev Uses ethscription number as token ID and name, while transaction hash remains the primary identifier for function calls
 contract Ethscriptions is ERC721EthscriptionsUpgradeable {
     using LibString for *;
-    
-    /// @dev Maximum chunk size for SSTORE2 (24KB - 1 byte for STOP opcode)
-    uint256 private constant CHUNK_SIZE = 24575;
-    
-    /// @dev L1Block predeploy for getting L1 block info
-    L1Block constant L1_BLOCK = L1Block(Predeploys.L1_BLOCK_ATTRIBUTES);
-    
+    using SSTORE2ChunkedStorageLib for address[];
+    using EthscriptionsRendererLib for Ethscription;
+
+    // =============================================================
+    //                          STRUCTS
+    // =============================================================
+
     struct ContentInfo {
         bytes32 contentUriHash;  // SHA256 of raw content URI string (for protocol uniqueness)
         bytes32 contentSha;      // SHA256 of decoded raw bytes (for storage reference)
@@ -43,18 +44,12 @@ contract Ethscriptions is ERC721EthscriptionsUpgradeable {
         bytes32 l1BlockHash;     // L1 block hash when created
     }
 
-    struct ContentData {
-        bytes32 contentSha;      // SHA256 of raw bytes
-        address[] pointers;      // SSTORE2 pointers to content chunks
-        uint256 size;           // Size of raw content
-    }
-    
     struct ProtocolParams {
-        string protocol;  // Protocol identifier (e.g., "erc-20", "collections", etc.)
-        string operation; // Operation to perform (e.g., "mint", "deploy", "create_collection", etc.)
-        bytes data;       // ABI-encoded parameters specific to the protocol/operation
+        string protocolName;  // Protocol identifier (e.g., "erc-20", "collections", etc.)
+        string operation;     // Operation to perform (e.g., "mint", "deploy", "create_collection", etc.)
+        bytes data;          // ABI-encoded parameters specific to the protocol/operation
     }
-    
+
     struct CreateEthscriptionParams {
         bytes32 transactionHash;
         bytes32 contentUriHash;  // SHA256 of raw content URI (for protocol uniqueness)
@@ -67,44 +62,70 @@ contract Ethscriptions is ERC721EthscriptionsUpgradeable {
         ProtocolParams protocolParams;  // Protocol operation data (optional)
     }
 
-    /// @dev Transaction hash => Ethscription data
-    mapping(bytes32 => Ethscription) internal ethscriptions;
-    
-    /// @dev Content SHA => ContentData (stores actual content and metadata)
-    mapping(bytes32 => ContentData) public contentBySha;
+    // =============================================================
+    //                     CONSTANTS & IMMUTABLES
+    // =============================================================
 
-    /// @dev Content URI hash => exists (for protocol uniqueness check)
-    mapping(bytes32 => bool) public contentUriExists;
-    
-    // totalSupply is now inherited from ERC721EnumerableUpgradeable
-
-    /// @dev Mapping from ethscription number (token ID) to transaction hash
-    mapping(uint256 => bytes32) public tokenIdToTransactionHash;
+    /// @dev L1Block predeploy for getting L1 block info
+    L1Block constant l1Block = L1Block(Predeploys.L1_BLOCK_ATTRIBUTES);
 
     /// @dev Ethscriptions Prover contract (pre-deployed at known address)
     EthscriptionsProver public constant prover = EthscriptionsProver(Predeploys.ETHSCRIPTIONS_PROVER);
+
+    // =============================================================
+    //                      STATE VARIABLES
+    // =============================================================
+
+    /// @dev Transaction hash => Ethscription data
+    mapping(bytes32 => Ethscription) internal ethscriptions;
+
+    /// @dev Content SHA => SSTORE2 pointers array
+    mapping(bytes32 => address[]) public contentPointersBySha;
+
+    /// @dev Content URI hash => first ethscription tx hash that used it (for protocol uniqueness check)
+    /// @dev bytes32(0) means unused, non-zero means the content URI has been used
+    mapping(bytes32 => bytes32) public firstEthscriptionByContentUri;
+
+    /// @dev Mapping from ethscription number (token ID) to transaction hash
+    mapping(uint256 => bytes32) public tokenIdToTransactionHash;
 
     /// @dev Protocol registry - maps protocol names to handler addresses
     mapping(string => address) public protocolHandlers;
 
     /// @dev Track which protocol an ethscription uses
-    mapping(bytes32 => string) public ethscriptionProtocol;
-
-    /// @dev Event emitted when a protocol handler is registered
-    event ProtocolRegistered(string indexed protocol, address indexed handler);
+    mapping(bytes32 => string) public protocolOf;
 
     /// @dev Array of genesis ethscription transaction hashes that need events emitted
     /// @notice This array is populated during genesis and cleared (by popping) when events are emitted
     bytes32[] internal pendingGenesisEvents;
-    
+
+    // =============================================================
+    //                      CUSTOM ERRORS
+    // =============================================================
+
+    error DuplicateContentUri();
+    error InvalidCreator();
+    error EthscriptionAlreadyExists();
+    error EthscriptionDoesNotExist();
+    error OnlyDepositor();
+    error InvalidHandler();
+    error ProtocolAlreadyRegistered();
+    error PreviousOwnerMismatch();
+    error NoSuccessfulTransfers();
+    error TokenDoesNotExist();
+
+    // =============================================================
+    //                          EVENTS
+    // =============================================================
+
     /// @notice Emitted when a new ethscription is created
     event EthscriptionCreated(
         bytes32 indexed transactionHash,
         address indexed creator,
         address indexed initialOwner,
+        bytes32 contentUriHash,
         bytes32 contentSha,
-        uint256 ethscriptionNumber,
-        uint256 pointerCount
+        uint256 ethscriptionNumber
     );
 
     /// @notice Emitted when an ethscription is transferred (Ethscriptions protocol semantics)
@@ -117,11 +138,8 @@ contract Ethscriptions is ERC721EthscriptionsUpgradeable {
         uint256 ethscriptionNumber
     );
 
-    error DuplicateContentUri();
-    error InvalidCreator();
-    error EmptyContent();
-    error EthscriptionAlreadyExists();
-    error EthscriptionDoesNotExist();
+    /// @notice Emitted when a protocol handler is registered
+    event ProtocolRegistered(string indexed protocol, address indexed handler);
 
     /// @notice Emitted when a protocol handler operation fails but ethscription continues
     event ProtocolHandlerFailed(
@@ -133,16 +151,425 @@ contract Ethscriptions is ERC721EthscriptionsUpgradeable {
     /// @notice Emitted when a protocol handler operation succeeds
     event ProtocolHandlerSuccess(
         bytes32 indexed transactionHash,
-        string protocol
+        string protocol,
+        bytes returnData
     );
 
-
+    // =============================================================
+    //                         MODIFIERS
+    // =============================================================
 
     /// @notice Modifier to emit pending genesis events on first real creation
     modifier emitGenesisEvents() {
         _emitPendingGenesisEvents();
         _;
     }
+
+    /// @notice Modifier to require that an ethscription exists
+    /// @param transactionHash The transaction hash to check
+    modifier requireExists(bytes32 transactionHash) {
+        if (!_ethscriptionExists(transactionHash)) revert EthscriptionDoesNotExist();
+        _;
+    }
+
+    // =============================================================
+    //                    ADMIN/SETUP FUNCTIONS
+    // =============================================================
+
+    /// @notice Register a protocol handler
+    /// @param protocol The protocol identifier (e.g., "erc-20", "collections")
+    /// @param handler The address of the handler contract
+    /// @dev Only callable by the depositor address (used during genesis setup)
+    function registerProtocol(string calldata protocol, address handler) external {
+        if (msg.sender != Predeploys.DEPOSITOR_ACCOUNT) revert OnlyDepositor();
+        if (handler == address(0)) revert InvalidHandler();
+        if (protocolHandlers[protocol] != address(0)) revert ProtocolAlreadyRegistered();
+
+        protocolHandlers[protocol] = handler;
+        emit ProtocolRegistered(protocol, handler);
+    }
+
+    // =============================================================
+    //                    CORE EXTERNAL FUNCTIONS
+    // =============================================================
+
+    /// @notice Create (mint) a new ethscription token
+    /// @dev Called via system transaction with msg.sender spoofed as the actual creator
+    /// @param params Struct containing all ethscription creation parameters
+    function createEthscription(
+        CreateEthscriptionParams calldata params
+    ) external emitGenesisEvents returns (uint256 tokenId) {
+        address creator = msg.sender;
+
+        if (creator == address(0)) revert InvalidCreator();
+        if (_ethscriptionExists(params.transactionHash)) revert EthscriptionAlreadyExists();
+        
+        bool contentUriAlreadySeen = firstEthscriptionByContentUri[params.contentUriHash] != bytes32(0);
+
+        if (contentUriAlreadySeen) {
+            if (!params.esip6) revert DuplicateContentUri();
+        } else {
+            firstEthscriptionByContentUri[params.contentUriHash] = params.transactionHash;
+        }
+
+        // Store content and get content SHA (of raw bytes)
+        bytes32 contentSha = _storeContent(params.content);
+
+        ethscriptions[params.transactionHash] = Ethscription({
+            content: ContentInfo({
+                contentUriHash: params.contentUriHash,
+                contentSha: contentSha,
+                mimetype: params.mimetype,
+                mediaType: params.mediaType,
+                mimeSubtype: params.mimeSubtype,
+                esip6: params.esip6
+            }),
+            creator: creator,
+            initialOwner: params.initialOwner,
+            previousOwner: creator, // Initially same as creator
+            ethscriptionNumber: totalSupply(),
+            createdAt: block.timestamp,
+            l1BlockNumber: l1Block.number(),
+            l2BlockNumber: uint64(block.number),
+            l1BlockHash: l1Block.hash()
+        });
+
+        // Use ethscription number as token ID
+        tokenId = totalSupply();
+
+        // Store the mapping from token ID to transaction hash
+        tokenIdToTransactionHash[tokenId] = params.transactionHash;
+
+        // Mint to initial owner (if address(0), mint to creator then transfer)
+        if (params.initialOwner == address(0)) {
+            _mint(creator, tokenId);
+            _transfer(creator, address(0), tokenId);
+        } else {
+            _mint(params.initialOwner, tokenId);
+        }
+
+        emit EthscriptionCreated(
+            params.transactionHash,
+            creator,
+            params.initialOwner,
+            params.contentUriHash,
+            contentSha,
+            tokenId
+        );
+
+        // Handle protocol operations (if any)
+        _callProtocolOperation(params.transactionHash, params.protocolParams);
+    }
+
+    /// @notice Transfer an ethscription
+    /// @dev Called via system transaction with msg.sender spoofed as 'from'
+    /// @param to The recipient address (can be address(0) for burning)
+    /// @param transactionHash The ethscription to transfer (used to find token ID)
+    function transferEthscription(
+        address to,
+        bytes32 transactionHash
+    ) external requireExists(transactionHash) {
+        // Get the ethscription number to use as token ID
+        Ethscription memory etsc = ethscriptions[transactionHash];
+        uint256 tokenId = etsc.ethscriptionNumber;
+        // Standard ERC721 transfer will handle authorization
+        transferFrom(msg.sender, to, tokenId);
+    }
+
+    /// @notice Transfer an ethscription with previous owner validation (ESIP-2)
+    /// @dev Called via system transaction with msg.sender spoofed as 'from'
+    /// @param to The recipient address (can be address(0) for burning)
+    /// @param transactionHash The ethscription to transfer
+    /// @param previousOwner The required previous owner for validation
+    function transferEthscriptionForPreviousOwner(
+        address to,
+        bytes32 transactionHash,
+        address previousOwner
+    ) external requireExists(transactionHash) {
+        // Verify the previous owner matches
+        if (ethscriptions[transactionHash].previousOwner != previousOwner) {
+            revert PreviousOwnerMismatch();
+        }
+
+        // Get the ethscription number to use as token ID
+        Ethscription memory etsc = ethscriptions[transactionHash];
+        uint256 tokenId = etsc.ethscriptionNumber;
+        // Use transferFrom which now handles burns when to == address(0)
+        transferFrom(msg.sender, to, tokenId);
+    }
+
+    /// @notice Transfer multiple ethscriptions to a single recipient
+    /// @dev Continues transferring even if individual transfers fail due to wrong ownership
+    /// @param transactionHashes Array of ethscription hashes to transfer
+    /// @param to The recipient address (can be address(0) for burning)
+    /// @return successCount Number of successful transfers
+    function transferMultipleEthscriptions(
+        bytes32[] calldata transactionHashes,
+        address to
+    ) external returns (uint256 successCount) {
+        for (uint256 i = 0; i < transactionHashes.length; i++) {
+            // Get the ethscription to find its token ID
+            if (!_ethscriptionExists(transactionHashes[i])) continue; // Skip non-existent ethscriptions
+            Ethscription memory etsc = ethscriptions[transactionHashes[i]];
+
+            uint256 tokenId = etsc.ethscriptionNumber;
+
+            // Check if sender owns this token before attempting transfer
+            // This prevents reverts and allows us to continue
+            if (_ownerOf(tokenId) == msg.sender) {
+                // Perform the transfer directly using internal _update
+                _update(to, tokenId, msg.sender);
+                successCount++;
+            }
+            // If sender doesn't own the token, just continue to next one
+        }
+
+        if (successCount == 0) revert NoSuccessfulTransfers();
+    }
+
+    // =============================================================
+    //                      VIEW FUNCTIONS
+    // =============================================================
+
+    // ---------------------- Token Metadata ----------------------
+
+    function name() public pure override returns (string memory) {
+        return "Ethscriptions";
+    }
+    
+    function symbol() public pure override returns (string memory) {
+        return "ETHSCRIPTIONS";
+    }
+
+    // ---------------------- Token URI & Media ----------------------
+
+    /// @notice Returns the full data URI for a token
+    function tokenURI(uint256 tokenId) public view override returns (string memory) {
+        // Find the transaction hash for this token ID (ethscription number)
+        bytes32 txHash = tokenIdToTransactionHash[tokenId];
+        if (!_ethscriptionExists(txHash)) revert TokenDoesNotExist();
+        Ethscription storage etsc = ethscriptions[txHash];
+
+        // Get content
+        bytes memory content = getEthscriptionContent(txHash);
+
+        // Build complete token URI using the library - it handles everything internally
+        return EthscriptionsRendererLib.buildTokenURI(etsc, txHash, content);
+    }
+
+    /// @notice Get the media URI for an ethscription (image or animation_url)
+    /// @param txHash The transaction hash of the ethscription
+    /// @return mediaType Either "image" or "animation_url"
+    /// @return mediaUri The data URI for the media
+    function getMediaUri(bytes32 txHash) external view requireExists(txHash) returns (string memory mediaType, string memory mediaUri) {
+        Ethscription storage etsc = ethscriptions[txHash];
+        bytes memory content = getEthscriptionContent(txHash);
+        return etsc.getMediaUri(content);
+    }
+
+    // -------------------- Data Retrieval --------------------
+
+    /// @notice Get ethscription details (returns struct to avoid stack too deep)
+    function getEthscription(bytes32 transactionHash) external view requireExists(transactionHash) returns (Ethscription memory) {
+        return ethscriptions[transactionHash];
+    }
+
+    /// @notice Get content for an ethscription
+    function getEthscriptionContent(bytes32 txHash) public view requireExists(txHash) returns (bytes memory) {
+        Ethscription storage etsc = ethscriptions[txHash];
+        address[] storage pointers = contentPointersBySha[etsc.content.contentSha];
+        // Empty content is valid - returns "" for empty pointers array
+        return pointers.read();
+    }
+
+    /// @notice Get ethscription details and content in a single call
+    /// @param txHash The transaction hash to look up
+    /// @return ethscription The ethscription struct
+    /// @return content The content bytes
+    function getEthscriptionWithContent(bytes32 txHash) external view requireExists(txHash) returns (Ethscription memory ethscription, bytes memory content) {
+        ethscription = ethscriptions[txHash];
+        address[] storage pointers = contentPointersBySha[ethscription.content.contentSha];
+        // Empty content is valid - returns "" for empty pointers array
+        content = pointers.read();
+    }
+
+    // ---------------- Ownership & Existence Checks ----------------
+
+    /// @notice Check if an ethscription exists
+    /// @param transactionHash The transaction hash to check
+    /// @return true if the ethscription exists
+    function exists(bytes32 transactionHash) external view returns (bool) {
+        return _ethscriptionExists(transactionHash);
+    }
+    
+    function exists(uint256 tokenId) external view returns (bool) {
+        return _ethscriptionExists(tokenIdToTransactionHash[tokenId]);
+    }
+
+    /// @notice Get owner of an ethscription by transaction hash
+    /// @dev Overload of ownerOf that accepts transaction hash instead of token ID
+    function ownerOf(bytes32 transactionHash) external view requireExists(transactionHash) returns (address) {
+        Ethscription storage etsc = ethscriptions[transactionHash];
+        uint256 tokenId = etsc.ethscriptionNumber;
+
+        return ownerOf(tokenId);
+    }
+
+    /// @notice Get the token ID (ethscription number) for a given transaction hash
+    /// @param transactionHash The transaction hash to look up
+    /// @return The token ID (ethscription number)
+    function getTokenId(bytes32 transactionHash) external view requireExists(transactionHash) returns (uint256) {
+        return ethscriptions[transactionHash].ethscriptionNumber;
+    }
+
+    // =============================================================
+    //                   INTERNAL FUNCTIONS
+    // =============================================================
+
+    /// @dev Override _update to track previous owner and handle token transfers
+    function _update(address to, uint256 tokenId, address auth) internal virtual override returns (address from) {
+        // Find the transaction hash for this token ID (ethscription number)
+        bytes32 txHash = tokenIdToTransactionHash[tokenId];
+        Ethscription storage etsc = ethscriptions[txHash];
+
+        // Call parent implementation first to handle the actual update
+        from = super._update(to, tokenId, auth);
+
+        if (from == address(0)) {
+            // Mint: emit once when minted directly to initial owner
+            if (to == etsc.initialOwner) {
+                emit EthscriptionTransferred(txHash, etsc.creator, to, tokenId);
+            }
+            // no previousOwner update or tokenManager call on mint
+        } else {
+            // Transfers (including creator -> address(0))
+            emit EthscriptionTransferred(txHash, from, to, tokenId);
+            etsc.previousOwner = from;
+
+            // Notify protocol handler about the transfer if this ethscription has a protocol
+            _notifyProtocolTransfer(txHash, from, to);
+        }
+
+        // Queue ethscription for batch proving at block boundary once proving is live
+        _queueForProving(txHash);
+    }
+
+    /// @notice Check if an ethscription exists
+    /// @dev An ethscription exists if it has been created (has a creator set)
+    /// @param transactionHash The transaction hash to check
+    /// @return True if the ethscription exists
+    function _ethscriptionExists(bytes32 transactionHash) internal view returns (bool) {
+        // Check if this ethscription has been created
+        // We can't use _tokenExists here because we need the tokenId first
+        // Instead, check if creator is set (ethscriptions are never created with zero creator)
+        return ethscriptions[transactionHash].creator != address(0);
+    }
+
+    /// @notice Internal helper to store content and return its SHA
+    /// @param content The raw content bytes to store
+    /// @return contentSha The SHA256 hash of the content
+    function _storeContent(bytes calldata content) internal returns (bytes32 contentSha) {
+        // Compute SHA256 hash of content first
+        contentSha = sha256(content);
+
+        // Check if content already exists
+        address[] storage existingPointers = contentPointersBySha[contentSha];
+
+        // Check if content was already stored (pointers array will be non-empty for stored content)
+        if (existingPointers.length > 0) {
+            // Content already stored, just return the SHA
+            return contentSha;
+        }
+
+        // Content doesn't exist, store it using SSTORE2
+        address[] memory pointers = SSTORE2ChunkedStorageLib.store(content);
+
+        // Store pointers array
+        contentPointersBySha[contentSha] = pointers;
+
+        return contentSha;
+    }
+
+    function _queueForProving(bytes32 txHash) internal {
+        if (block.timestamp >= Constants.historicalBackfillApproxDoneAt) {
+            prover.queueEthscription(txHash);
+        }
+    }
+
+    /// @notice Call a protocol handler operation during ethscription creation
+    /// @param txHash The ethscription transaction hash
+    /// @param protocolParams The protocol parameters struct
+    function _callProtocolOperation(
+        bytes32 txHash,
+        ProtocolParams calldata protocolParams
+    ) internal {
+        // Skip if no protocol specified
+        if (bytes(protocolParams.protocolName).length == 0) {
+            return;
+        }
+
+        // Track which protocol this ethscription uses
+        protocolOf[txHash] = protocolParams.protocolName;
+
+        address handler = protocolHandlers[protocolParams.protocolName];
+
+        // Skip if no handler is registered
+        if (handler == address(0)) {
+            return;
+        }
+
+        // Encode the function call with operation name
+        bytes memory callData = abi.encodeWithSignature(
+            string.concat("op_", protocolParams.operation, "(bytes32,bytes)"),
+            txHash,
+            protocolParams.data
+        );
+
+        // Call the handler - failures don't revert ethscription creation
+        (bool success, bytes memory returnData) = handler.call(callData);
+
+        if (!success) {
+            emit ProtocolHandlerFailed(txHash, protocolParams.protocolName, returnData);
+        } else {
+            emit ProtocolHandlerSuccess(txHash, protocolParams.protocolName, returnData);
+        }
+    }
+
+    /// @notice Notify protocol handler about an ethscription transfer
+    /// @param txHash The ethscription transaction hash
+    /// @param from The address transferring from
+    /// @param to The address transferring to
+    function _notifyProtocolTransfer(
+        bytes32 txHash,
+        address from,
+        address to
+    ) internal {
+        string memory protocol = protocolOf[txHash];
+
+        // Skip if no protocol assigned
+        if (bytes(protocol).length == 0) {
+            return;
+        }
+
+        address handler = protocolHandlers[protocol];
+
+        // Skip if no handler is registered
+        if (handler == address(0)) {
+            return;
+        }
+
+        // Use try/catch for cleaner error handling
+        try IProtocolHandler(handler).onTransfer(txHash, from, to) {
+            // onTransfer doesn't return data, so pass empty bytes
+            emit ProtocolHandlerSuccess(txHash, protocol, "");
+        } catch (bytes memory revertData) {
+            emit ProtocolHandlerFailed(txHash, protocol, revertData);
+        }
+    }
+
+    // =============================================================
+    //                    PRIVATE FUNCTIONS
+    // =============================================================
 
     /// @notice Emit all pending genesis events
     /// @dev Emits events in chronological order then clears the array
@@ -191,623 +618,15 @@ contract Ethscriptions is ERC721EthscriptionsUpgradeable {
                 txHash,
                 etsc.creator,
                 etsc.initialOwner,
+                etsc.content.contentUriHash,
                 etsc.content.contentSha,
-                etsc.ethscriptionNumber,
-                contentBySha[etsc.content.contentSha].pointers.length
+                etsc.ethscriptionNumber
             );
         }
 
         // Pop the array until it's empty
         while (pendingGenesisEvents.length > 0) {
             pendingGenesisEvents.pop();
-        }
-    }
-
-    /// @notice Check if an ethscription exists
-    /// @dev An ethscription exists if it has been created (has a creator set)
-    /// @param transactionHash The transaction hash to check
-    /// @return True if the ethscription exists
-    function _ethscriptionExists(bytes32 transactionHash) internal view returns (bool) {
-        // Check if this ethscription has been created
-        // We can't use _tokenExists here because we need the tokenId first
-        // Instead, check if creator is set (ethscriptions are never created with zero creator)
-        return ethscriptions[transactionHash].creator != address(0);
-    }
-
-    /// @notice Modifier to require that an ethscription exists
-    /// @param transactionHash The transaction hash to check
-    modifier requireExists(bytes32 transactionHash) {
-        if (!_ethscriptionExists(transactionHash)) revert EthscriptionDoesNotExist();
-        _;
-    }
-
-    
-    function name() public pure override returns (string memory) {
-        return "Ethscriptions";
-    }
-    
-    function symbol() public pure override returns (string memory) {
-        return "ETHSCRIPTIONS";
-    }
-
-    /// @notice Register a protocol handler
-    /// @param protocol The protocol identifier (e.g., "erc-20", "collections")
-    /// @param handler The address of the handler contract
-    /// @dev Only callable by the depositor address (used during genesis setup)
-    function registerProtocol(string calldata protocol, address handler) external {
-        // Only the depositor address can register protocols
-        // This is set during genesis and used for initial protocol setup
-        require(
-            msg.sender == Predeploys.DEPOSITOR_ACCOUNT,
-            "Only depositor can register protocols"
-        );
-        require(handler != address(0), "Invalid handler address");
-        require(protocolHandlers[protocol] == address(0), "Protocol already registered");
-        protocolHandlers[protocol] = handler;
-        emit ProtocolRegistered(protocol, handler);
-    }
-
-    /// @notice Create (mint) a new ethscription token
-    /// @dev Called via system transaction with msg.sender spoofed as the actual creator
-    /// @param params Struct containing all ethscription creation parameters
-    function createEthscription(
-        CreateEthscriptionParams calldata params
-    ) external emitGenesisEvents returns (uint256 tokenId) {
-        address creator = msg.sender;
-
-        if (creator == address(0)) revert InvalidCreator();
-        // Allow empty content - valid data URIs can have empty payloads (e.g., "data:,")
-        if (_ethscriptionExists(params.transactionHash)) revert EthscriptionAlreadyExists();
-
-        // Check protocol uniqueness using content URI hash
-        if (contentUriExists[params.contentUriHash]) {
-            if (!params.esip6) revert DuplicateContentUri();
-        }
-
-        // Store content and get content SHA (of raw bytes)
-        bytes32 contentSha = _storeContent(params.content);
-
-        // Mark content URI as used
-        contentUriExists[params.contentUriHash] = true;
-
-        ethscriptions[params.transactionHash] = Ethscription({
-            content: ContentInfo({
-                contentUriHash: params.contentUriHash,
-                contentSha: contentSha,
-                mimetype: params.mimetype,
-                mediaType: params.mediaType,
-                mimeSubtype: params.mimeSubtype,
-                esip6: params.esip6
-            }),
-            creator: creator,
-            initialOwner: params.initialOwner,
-            previousOwner: creator, // Initially same as creator
-            ethscriptionNumber: totalSupply(),
-            createdAt: block.timestamp,
-            l1BlockNumber: L1_BLOCK.number(),
-            l2BlockNumber: uint64(block.number),
-            l1BlockHash: L1_BLOCK.hash()
-        });
-
-        // Use ethscription number as token ID
-        tokenId = totalSupply();
-
-        // Store the mapping from token ID to transaction hash
-        tokenIdToTransactionHash[tokenId] = params.transactionHash;
-
-        // Token count is automatically tracked by enumerable's _update
-
-        // Mint to initial owner (if address(0), mint to creator then transfer)
-        if (params.initialOwner == address(0)) {
-            _mint(creator, tokenId);
-            _transfer(creator, address(0), tokenId);
-        } else {
-            _mint(params.initialOwner, tokenId);
-        }
-
-        emit EthscriptionCreated(
-            params.transactionHash,
-            creator,
-            params.initialOwner,
-            contentSha,
-            tokenId,
-            contentBySha[contentSha].pointers.length
-        );
-
-        // Handle protocol operations if a protocol is specified
-        if (bytes(params.protocolParams.protocol).length > 0) {
-            // Track which protocol this ethscription uses
-            ethscriptionProtocol[params.transactionHash] = params.protocolParams.protocol;
-
-            address handler = protocolHandlers[params.protocolParams.protocol];
-            // Call the operation-specific function directly
-            // We encode with (bytes32, bytes) - the handler will decode the bytes into its expected struct
-            bytes memory callData = abi.encodeWithSignature(
-                string.concat("op_", params.protocolParams.operation, "(bytes32,bytes)"),
-                params.transactionHash,
-                params.protocolParams.data
-            );
-            
-            (bool success, bytes memory revertData) = handler.call(callData);
-
-            if (!success) {
-                // Protocol operation failed, but ethscription creation should continue
-                // The ethscription is still valid even if protocol processing fails
-                emit ProtocolHandlerFailed(params.transactionHash, params.protocolParams.protocol, revertData);
-            } else {
-                emit ProtocolHandlerSuccess(params.transactionHash, params.protocolParams.protocol);
-            }
-        }
-    }
-
-    /// @notice Transfer an ethscription
-    /// @dev Called via system transaction with msg.sender spoofed as 'from'
-    /// @param to The recipient address (can be address(0) for burning)
-    /// @param transactionHash The ethscription to transfer (used to find token ID)
-    function transferEthscription(
-        address to,
-        bytes32 transactionHash
-    ) external requireExists(transactionHash) {
-        // Get the ethscription number to use as token ID
-        Ethscription memory etsc = ethscriptions[transactionHash];
-        uint256 tokenId = etsc.ethscriptionNumber;
-        // Standard ERC721 transfer will handle authorization
-        transferFrom(msg.sender, to, tokenId);
-    }
-
-    // transferFrom is inherited from base and already supports transfers to address(0)
-
-    /// @notice Transfer an ethscription with previous owner validation (ESIP-2)
-    /// @dev Called via system transaction with msg.sender spoofed as 'from'
-    /// @param to The recipient address (can be address(0) for burning)
-    /// @param transactionHash The ethscription to transfer
-    /// @param previousOwner The required previous owner for validation
-    function transferEthscriptionForPreviousOwner(
-        address to,
-        bytes32 transactionHash,
-        address previousOwner
-    ) external requireExists(transactionHash) {
-        // Verify the previous owner matches
-        require(
-            ethscriptions[transactionHash].previousOwner == previousOwner,
-            "Previous owner mismatch"
-        );
-
-        // Get the ethscription number to use as token ID
-        Ethscription memory etsc = ethscriptions[transactionHash];
-        uint256 tokenId = etsc.ethscriptionNumber;
-        // Use transferFrom which now handles burns when to == address(0)
-        transferFrom(msg.sender, to, tokenId);
-    }
-
-    /// @notice Transfer multiple ethscriptions to a single recipient
-    /// @dev Continues transferring even if individual transfers fail due to wrong ownership
-    /// @param transactionHashes Array of ethscription hashes to transfer
-    /// @param to The recipient address (can be address(0) for burning)
-    /// @return successCount Number of successful transfers
-    function transferMultipleEthscriptions(
-        bytes32[] calldata transactionHashes,
-        address to
-    ) external returns (uint256 successCount) {
-        for (uint256 i = 0; i < transactionHashes.length; i++) {
-            // Get the ethscription to find its token ID
-            if (!_ethscriptionExists(transactionHashes[i])) continue; // Skip non-existent ethscriptions
-            Ethscription memory etsc = ethscriptions[transactionHashes[i]];
-
-            uint256 tokenId = etsc.ethscriptionNumber;
-
-            // Check if sender owns this token before attempting transfer
-            // This prevents reverts and allows us to continue
-            if (_ownerOf(tokenId) == msg.sender) {
-                // Perform the transfer directly using internal _update
-                _update(to, tokenId, msg.sender);
-                successCount++;
-            }
-            // If sender doesn't own the token, just continue to next one
-        }
-
-        require(successCount > 0, "No successful transfers");
-    }
-
-    /// @dev Override _update to track previous owner and handle token transfers
-    function _update(address to, uint256 tokenId, address auth) internal virtual override returns (address from) {
-        // Find the transaction hash for this token ID (ethscription number)
-        bytes32 txHash = tokenIdToTransactionHash[tokenId];
-        Ethscription storage etsc = ethscriptions[txHash];
-
-        // Call parent implementation first to handle the actual update
-        from = super._update(to, tokenId, auth);
-
-        if (from == address(0)) {
-            // Mint: emit once when minted directly to initial owner
-            if (to == etsc.initialOwner) {
-                emit EthscriptionTransferred(txHash, etsc.creator, to, tokenId);
-            }
-            // no previousOwner update or tokenManager call on mint
-        } else {
-            // Transfers (including creator -> address(0))
-            emit EthscriptionTransferred(txHash, from, to, tokenId);
-            etsc.previousOwner = from;
-
-            // Notify protocol handler about the transfer if this ethscription has a protocol
-            string memory protocol = ethscriptionProtocol[txHash];
-            if (bytes(protocol).length > 0) {
-                address handler = protocolHandlers[protocol];
-                if (handler != address(0)) {
-                    try IProtocolHandler(handler).onTransfer(txHash, from, to) {
-                        emit ProtocolHandlerSuccess(txHash, protocol);
-                    } catch (bytes memory revertData) {
-                        emit ProtocolHandlerFailed(txHash, protocol, revertData);
-                    }
-                }
-            }
-        }
-
-        // Queue ethscription for batch proving at block boundary once proving is live
-        _queueForProving(txHash);
-    }
-
-    /// @notice Get ethscription details (returns struct to avoid stack too deep)
-    function getEthscription(bytes32 transactionHash) external view requireExists(transactionHash) returns (Ethscription memory) {
-        return ethscriptions[transactionHash];
-    }
-    
-    function ownerOf(bytes32 transactionHash) external view requireExists(transactionHash) returns (address) {
-        Ethscription storage etsc = ethscriptions[transactionHash];
-        uint256 tokenId = etsc.ethscriptionNumber;
-        
-        return ownerOf(tokenId);
-    }
-
-    /// @notice Returns the full data URI for a token
-    function tokenURI(uint256 tokenId) public view override returns (string memory) {
-        // Find the transaction hash for this token ID (ethscription number)
-        bytes32 txHash = tokenIdToTransactionHash[tokenId];
-        require(_ethscriptionExists(txHash), "Token does not exist");
-        Ethscription storage etsc = ethscriptions[txHash];
-
-        // Build common parts of the JSON
-        string memory jsonStart = string.concat(
-            '{"name":"Ethscription #',
-            tokenId.toString(),
-            '","description":"Ethscription #',
-            tokenId.toString(),
-            ' created by ',
-            etsc.creator.toHexString(),
-            '",'
-        );
-
-        // Use getMediaUri to generate media field
-        (string memory mediaType, string memory mediaUri) = this.getMediaUri(txHash);
-        string memory mediaField = string.concat(
-            '"', mediaType, '":"',
-            mediaUri.escapeJSON(),
-            '"'
-        );
-
-        string memory json = string.concat(
-            jsonStart,
-            mediaField,
-            ',"attributes":',
-            _getAttributes(etsc),
-            '}'
-        );
-
-        // Return as base64-encoded data URI
-        return string.concat(
-            "data:application/json;base64,",
-            Base64.encode(bytes(json))
-        );
-    }
-
-    /// @dev Helper function to build attributes JSON array
-    function _getAttributes(Ethscription storage etsc) internal view returns (string memory) {
-        // Build in chunks to avoid stack too deep
-        string memory part1 = string.concat(
-            '[{"trait_type":"Ethscription Number","display_type":"number","value":',
-            etsc.ethscriptionNumber.toString(),
-            '},{"trait_type":"Creator","value":"',
-            etsc.creator.toHexString(),
-            '"},{"trait_type":"Initial Owner","value":"',
-            etsc.initialOwner.toHexString(),
-            '"},{"trait_type":"Content SHA","value":"',
-            uint256(etsc.content.contentSha).toHexString()
-        );
-
-        string memory part2 = string.concat(
-            '"},{"trait_type":"MIME Type","value":"',
-            etsc.content.mimetype.escapeJSON(),
-            '"},{"trait_type":"Media Type","value":"',
-            etsc.content.mediaType.escapeJSON(),
-            '"},{"trait_type":"MIME Subtype","value":"',
-            etsc.content.mimeSubtype.escapeJSON(),
-            '"},{"trait_type":"ESIP-6","value":"',
-            etsc.content.esip6 ? "true" : "false"
-        );
-
-        string memory part3 = string.concat(
-            '"},{"trait_type":"L1 Block Number","display_type":"number","value":',
-            uint256(etsc.l1BlockNumber).toString(),
-            '},{"trait_type":"L2 Block Number","display_type":"number","value":',
-            uint256(etsc.l2BlockNumber).toString(),
-            '},{"trait_type":"Created At","display_type":"date","value":',
-            etsc.createdAt.toString(),
-            '}]'
-        );
-
-        return string.concat(part1, part2, part3);
-    }
-
-    /// @dev Helper function to read content for an ethscription
-    function getEthscriptionContent(bytes32 txHash) public view requireExists(txHash) returns (bytes memory) {
-        Ethscription storage etsc = ethscriptions[txHash];
-        ContentData storage contentData = contentBySha[etsc.content.contentSha];
-        require(contentData.contentSha != bytes32(0), "No content stored");
-
-        return _readFromPointers(contentData.pointers);
-    }
-
-    /// @notice Get ethscription details and content in a single call
-    /// @param txHash The transaction hash to look up
-    /// @return ethscription The ethscription struct
-    /// @return content The content bytes
-    function getEthscriptionWithContent(bytes32 txHash) external view requireExists(txHash) returns (Ethscription memory ethscription, bytes memory content) {
-        ethscription = ethscriptions[txHash];
-        ContentData storage contentData = contentBySha[ethscription.content.contentSha];
-        require(contentData.contentSha != bytes32(0), "No content stored");
-
-        content = _readFromPointers(contentData.pointers);
-    }
-
-    /// @dev Helper function to construct a base64-encoded data URI
-    function _constructDataURI(string memory mimetype, bytes memory content) internal pure returns (string memory) {
-        return string.concat(
-            "data:",
-            mimetype,
-            ";base64,",
-            Base64.encode(content)
-        );
-    }
-
-    /// @dev Helper function to wrap image in SVG for pixel-perfect rendering
-    function _wrapImageInSVG(string memory imageDataUri) internal pure returns (string memory) {
-        // SVG wrapper that enforces pixelated/nearest-neighbor scaling for pixel art
-        // Uses a 1200x1200 viewport with the image centered and scaled to fit
-        return string.concat(
-            '<svg width="1200" height="1200" viewBox="0 0 1200 1200" version="1.2" xmlns="http://www.w3.org/2000/svg" style="background-image:url(',
-            imageDataUri,
-            ');background-repeat:no-repeat;background-size:contain;background-position:center;image-rendering:-webkit-optimize-contrast;image-rendering:-moz-crisp-edges;image-rendering:pixelated;"></svg>'
-        );
-    }
-
-    /// @notice Get the media URI for an ethscription (image or animation_url)
-    /// @param txHash The transaction hash of the ethscription
-    /// @return mediaType Either "image" or "animation_url"
-    /// @return mediaUri The data URI for the media
-    function getMediaUri(bytes32 txHash) public view requireExists(txHash) returns (string memory mediaType, string memory mediaUri) {
-        Ethscription storage etsc = ethscriptions[txHash];
-
-        if (etsc.content.mimetype.startsWith("image/")) {
-            // Image content: wrap in SVG for pixel-perfect rendering
-            string memory imageDataUri = _getContentDataURI(txHash);
-            string memory svg = _wrapImageInSVG(imageDataUri);
-            string memory svgDataUri = _constructDataURI("image/svg+xml", bytes(svg));
-            return ("image", svgDataUri);
-        } else {
-            // Non-image content: use animation_url
-            string memory animationUrl;
-
-            // Check for media types that should pass through directly
-            if (etsc.content.mimetype.startsWith("video/") ||
-                etsc.content.mimetype.startsWith("audio/") ||
-                etsc.content.mimetype.eq("text/html")) {
-                // Video, audio, and HTML pass through directly as data URIs
-                animationUrl = _getContentDataURI(txHash);
-            } else {
-                // Everything else (text/plain, application/json, etc.) uses the HTML viewer
-                animationUrl = _getTextViewerDataURI(txHash);
-            }
-            return ("animation_url", animationUrl);
-        }
-    }
-
-    /// @dev Helper function to get content as data URI
-    function _getContentDataURI(bytes32 txHash) internal view returns (string memory) {
-        Ethscription storage etsc = ethscriptions[txHash];
-        bytes memory content = getEthscriptionContent(txHash);
-
-        // Always use base64 for safety and consistency
-        return _constructDataURI(etsc.content.mimetype, content);
-    }
-
-    /// @dev Helper function to generate minimal HTML viewer for text content
-    function _getTextViewerHTML(string memory encodedPayload, string memory mimetype) internal pure returns (string memory) {
-        // Ultra-minimal HTML with inline styles optimized for iframe display
-        // Uses dynamic viewport units and centers content without scrollbars
-        return string.concat(
-            '<!DOCTYPE html><html><head><meta charset="utf-8"/><meta name="viewport" content="width=device-width,initial-scale=1"/>',
-            '<style>*{box-sizing:border-box;margin:0;padding:0;border:0}body{padding:6dvw;background:#0b0b0c;color:#f5f5f5;font-family:monospace;display:flex;justify-content:center;align-items:center;min-height:100dvh;overflow:hidden}',
-            'pre{white-space:pre-wrap;word-break:break-word;overflow-wrap:anywhere;line-height:1.4;font-size:14px}</style></head>',
-            '<body><pre id="o"></pre><script>',
-            'const p="', encodedPayload, '";',
-            'const m="', mimetype.escapeJSON(), '";',  // Escape to prevent breaking out of JS string
-            'function d(b){try{return decodeURIComponent(atob(b).split("").map(c=>"%"+("00"+c.charCodeAt(0).toString(16)).slice(-2)).join(""))}catch{return null}}',
-            'const r=d(p);let t="";',
-            'if(r!==null){t=r;try{const j=JSON.parse(r);t=JSON.stringify(j,null,2)}catch{}}',
-            'else{t="data:"+m+";base64,"+p}',  // Reconstruct data URI if UTF-8 decoding fails
-            'document.getElementById("o").textContent=t||"(empty)";',
-            '</script></body></html>'
-        );
-    }
-
-    /// @dev Helper function to get text content as HTML viewer data URI
-    function _getTextViewerDataURI(bytes32 txHash) internal view returns (string memory) {
-        Ethscription memory etsc = ethscriptions[txHash];
-        bytes memory content = getEthscriptionContent(txHash);
-
-        // Base64 encode the content for embedding in HTML
-        string memory encodedContent = Base64.encode(content);
-
-        // Generate HTML with embedded content
-        string memory html = _getTextViewerHTML(encodedContent, etsc.content.mimetype);
-
-        // Return as base64-encoded HTML data URI
-        return _constructDataURI("text/html", bytes(html));
-    }
-
-
-    /// @notice Check if an ethscription exists
-    /// @param transactionHash The transaction hash to check
-    /// @return true if the ethscription exists
-    function exists(bytes32 transactionHash) external view returns (bool) {
-        return _ethscriptionExists(transactionHash);
-    }
-
-    /// @notice Get current owner of an ethscription
-    /// @dev Returns the actual owner, which may be address(0) for null-owned tokens or unminted tokens
-    function currentOwner(bytes32 transactionHash) external view requireExists(transactionHash) returns (address) {
-        Ethscription memory etsc = ethscriptions[transactionHash];
-        uint256 tokenId = etsc.ethscriptionNumber;
-        // Use _ownerOf which returns address(0) for non-existent tokens
-        return ownerOf(tokenId);
-    }
-
-    /// @notice Get the token ID (ethscription number) for a given transaction hash
-    /// @param transactionHash The transaction hash to look up
-    /// @return The token ID (ethscription number)
-    function getTokenId(bytes32 transactionHash) external view requireExists(transactionHash) returns (uint256) {
-        return ethscriptions[transactionHash].ethscriptionNumber;
-    }
-
-    /// @notice Get the number of content pointers for an ethscription
-    function getContentPointerCount(bytes32 transactionHash) external view requireExists(transactionHash) returns (uint256) {
-        Ethscription storage etsc = ethscriptions[transactionHash];
-        return contentBySha[etsc.content.contentSha].pointers.length;
-    }
-
-    /// @notice Get all content pointers for an ethscription
-    function getContentPointers(bytes32 transactionHash) external view requireExists(transactionHash) returns (address[] memory) {
-        Ethscription storage etsc = ethscriptions[transactionHash];
-        return contentBySha[etsc.content.contentSha].pointers;
-    }
-
-    /// @notice Read a specific chunk of content
-    /// @param transactionHash The ethscription transaction hash
-    /// @param index The chunk index to read
-    /// @return The chunk data
-    function readChunk(bytes32 transactionHash, uint256 index) external view requireExists(transactionHash) returns (bytes memory) {
-        Ethscription storage etsc = ethscriptions[transactionHash];
-        ContentData storage contentData = contentBySha[etsc.content.contentSha];
-        require(index < contentData.pointers.length, "Chunk index out of bounds");
-        return SSTORE2.read(contentData.pointers[index]);
-    }
-    
-    /// @notice Internal helper to store content and return its SHA
-    /// @param content The raw content bytes to store
-    /// @return contentSha The SHA256 hash of the content
-    function _storeContent(bytes calldata content) internal returns (bytes32 contentSha) {
-        // Compute SHA of raw bytes
-        contentSha = sha256(content);
-
-        // Check if content already exists
-        ContentData storage existingContent = contentBySha[contentSha];
-
-        // Check if content was already stored (contentSha will be non-zero for stored content)
-        if (existingContent.contentSha != bytes32(0)) {
-            // Content already stored, just return the SHA
-            return contentSha;
-        }
-
-        // New content: chunk and store via SSTORE2
-        uint256 contentLength = content.length;
-
-        address[] memory pointers;
-
-        if (contentLength > 0) {
-            uint256 numChunks = (contentLength + CHUNK_SIZE - 1) / CHUNK_SIZE;
-            pointers = new address[](numChunks);
-
-            for (uint256 i = 0; i < numChunks; i++) {
-                uint256 start = i * CHUNK_SIZE;
-                uint256 end = start + CHUNK_SIZE;
-                if (end > contentLength) {
-                    end = contentLength;
-                }
-
-                // Calldata slicing for efficiency
-                bytes calldata chunk = content[start:end];
-
-                // Store chunk via SSTORE2
-                pointers[i] = SSTORE2.write(chunk);
-            }
-        }
-        // For empty content, pointers remains an empty array
-
-        // Store content data (only raw bytes info, no metadata)
-        contentBySha[contentSha] = ContentData({
-            contentSha: contentSha,
-            pointers: pointers,
-            size: contentLength
-        });
-
-        return contentSha;
-    }
-
-    /// @dev Read content from multiple SSTORE2 pointers
-    function _readFromPointers(address[] storage pointers) private view returns (bytes memory) {
-        if (pointers.length == 0) {
-            return "";
-        }
-
-        if (pointers.length == 1) {
-            return SSTORE2.read(pointers[0]);
-        }
-
-        // Multiple pointers - efficient assembly concatenation
-        bytes memory content;
-        assembly {
-            // Calculate total size needed
-            let totalSize := 0
-            let pointersSlot := pointers.slot
-            let pointersLength := sload(pointersSlot)
-            let dataOffset := 0x01 // SSTORE2 data starts after STOP opcode
-
-            for { let i := 0 } lt(i, pointersLength) { i := add(i, 1) } {
-                // Array elements are stored at keccak256(slot) + index
-                mstore(0, pointersSlot)
-                let elementSlot := add(keccak256(0, 0x20), i)
-                let pointer := sload(elementSlot)
-                let codeSize := extcodesize(pointer)
-                totalSize := add(totalSize, sub(codeSize, dataOffset))
-            }
-
-            // Allocate result buffer
-            content := mload(0x40)
-            let contentPtr := add(content, 0x20)
-
-            // Copy data from each pointer
-            let currentOffset := 0
-            for { let i := 0 } lt(i, pointersLength) { i := add(i, 1) } {
-                mstore(0, pointersSlot)
-                let elementSlot := add(keccak256(0, 0x20), i)
-                let pointer := sload(elementSlot)
-                let codeSize := extcodesize(pointer)
-                let chunkSize := sub(codeSize, dataOffset)
-                extcodecopy(pointer, add(contentPtr, currentOffset), dataOffset, chunkSize)
-                currentOffset := add(currentOffset, chunkSize)
-            }
-
-            // Update length and free memory pointer with proper alignment
-            mstore(content, totalSize)
-            mstore(0x40, and(add(add(contentPtr, totalSize), 0x1f), not(0x1f)))
-        }
-
-        return content;
-    }
-    
-    function _queueForProving(bytes32 txHash) internal {
-        if (block.timestamp >= 1760630077) {
-            prover.queueEthscription(txHash);
         }
     }
 }

--- a/contracts/src/Ethscriptions.sol
+++ b/contracts/src/Ethscriptions.sol
@@ -484,8 +484,10 @@ contract Ethscriptions is ERC721EthscriptionsUpgradeable {
         // Content doesn't exist, store it using SSTORE2
         address[] memory pointers = SSTORE2ChunkedStorageLib.store(content);
 
-        // Store pointers array
-        contentPointersBySha[contentSha] = pointers;
+        // Only store non-empty pointer arrays (empty content doesn't need deduplication)
+        if (pointers.length > 0) {
+            contentPointersBySha[contentSha] = pointers;
+        }
 
         return contentSha;
     }

--- a/contracts/src/EthscriptionsERC20.sol
+++ b/contracts/src/EthscriptionsERC20.sol
@@ -5,47 +5,97 @@ import "./ERC20NullOwnerCappedUpgradeable.sol";
 import "./libraries/Predeploys.sol";
 
 /// @title EthscriptionsERC20
-/// @notice ERC20 with cap that supports null address ownership; only TokenManager can mint/transfer
+/// @notice ERC20 with cap that supports null address ownership
+/// @dev Only TokenManager can mint/transfer. User-initiated transfers are disabled.
 contract EthscriptionsERC20 is ERC20NullOwnerCappedUpgradeable {
-    address public constant tokenManager = Predeploys.TOKEN_MANAGER;
-    bytes32 public deployTxHash; // The ethscription hash that deployed this token
 
+    // =============================================================
+    //                         CONSTANTS
+    // =============================================================
+
+    /// @notice The TokenManager contract that controls this token
+    address public constant tokenManager = Predeploys.TOKEN_MANAGER;
+
+    // =============================================================
+    //                      STATE VARIABLES
+    // =============================================================
+
+    /// @notice The ethscription hash that deployed this token
+    bytes32 public deployTxHash;
+
+    // =============================================================
+    //                      CUSTOM ERRORS
+    // =============================================================
+
+    error OnlyTokenManager();
+    error TransfersOnlyViaEthscriptions();
+    error ApprovalsNotAllowed();
+
+    // =============================================================
+    //                         MODIFIERS
+    // =============================================================
+
+    modifier onlyTokenManager() {
+        if (msg.sender != tokenManager) revert OnlyTokenManager();
+        _;
+    }
+
+    // =============================================================
+    //                    EXTERNAL FUNCTIONS
+    // =============================================================
+
+    /// @notice Initialize the ERC20 token
+    /// @param name_ The token name
+    /// @param symbol_ The token symbol
+    /// @param cap_ The maximum supply cap (in 18 decimals)
+    /// @param deployTxHash_ The ethscription hash that deployed this token
     function initialize(
         string memory name_,
         string memory symbol_,
         uint256 cap_,
         bytes32 deployTxHash_
-    ) public initializer {
+    ) external initializer {
         __ERC20_init(name_, symbol_);
         __ERC20Capped_init(cap_);
         deployTxHash = deployTxHash_;
     }
 
-    modifier onlyTokenManager() {
-        require(msg.sender == tokenManager, "Only TokenManager");
-        _;
-    }
-
-    // TokenManager-only mint that allows to == address(0)
+    /// @notice Mint tokens (TokenManager only)
+    /// @dev Allows minting to address(0) for null ownership
+    /// @param to The recipient address (can be address(0))
+    /// @param amount The amount to mint (in 18 decimals)
     function mint(address to, uint256 amount) external onlyTokenManager {
         _mint(to, amount);
     }
 
-    // TokenManager-only transfer that allows to/from == address(0)
+    /// @notice Force transfer tokens (TokenManager only)
+    /// @dev Allows transfers to/from address(0) for null ownership
+    /// @param from The sender address (can be address(0))
+    /// @param to The recipient address (can be address(0))
+    /// @param amount The amount to transfer (in 18 decimals)
     function forceTransfer(address from, address to, uint256 amount) external onlyTokenManager {
         _update(from, to, amount);
     }
 
-    // Disable user-initiated ERC20 flows
+    // =============================================================
+    //                DISABLED ERC20 FUNCTIONS
+    // =============================================================
+
+    /// @notice User-initiated transfers are disabled
+    /// @dev All transfers must go through the Ethscriptions NFT
     function transfer(address, uint256) public pure override returns (bool) {
-        revert("Transfers only allowed via Ethscriptions NFT");
+        revert TransfersOnlyViaEthscriptions();
     }
 
+    /// @notice User-initiated transfers are disabled
+    /// @dev All transfers must go through the Ethscriptions NFT
     function transferFrom(address, address, uint256) public pure override returns (bool) {
-        revert("Transfers only allowed via Ethscriptions NFT");
+        revert TransfersOnlyViaEthscriptions();
     }
 
+    /// @notice Approvals are disabled
+    /// @dev All transfers are controlled by the TokenManager
     function approve(address, uint256) public pure override returns (bool) {
-        revert("Approvals not allowed");
+        revert ApprovalsNotAllowed();
     }
 }

--- a/contracts/src/EthscriptionsProver.sol
+++ b/contracts/src/EthscriptionsProver.sol
@@ -106,7 +106,7 @@ contract EthscriptionsProver {
     function _createAndSendProof(bytes32 ethscriptionTxHash, QueuedProof memory proofInfo) internal {
         // Get ethscription data including previous owner
         Ethscriptions.Ethscription memory etsc = ethscriptions.getEthscription(ethscriptionTxHash);
-        address currentOwner = ethscriptions.currentOwner(ethscriptionTxHash);
+        address currentOwner = ethscriptions.ownerOf(ethscriptionTxHash);
 
         // Create proof struct with all ethscription data
         EthscriptionDataProof memory proof = EthscriptionDataProof({

--- a/contracts/src/L2/L1Block.sol
+++ b/contracts/src/L2/L1Block.sol
@@ -90,7 +90,7 @@ contract L1Block {
     }
 
     function _flushProofsIfLive() internal {
-        if (block.timestamp >= 1760630077) {
+        if (block.timestamp >= Constants.historicalBackfillApproxDoneAt) {
             // Each proof includes its own block number and timestamp from when it was queued
             IEthscriptionsProver(Predeploys.ETHSCRIPTIONS_PROVER).flushAllProofs();
         }

--- a/contracts/src/libraries/Constants.sol
+++ b/contracts/src/libraries/Constants.sol
@@ -21,4 +21,6 @@ library Constants {
     /// @notice Storage slot for Initializable contract's initialized flag
     /// @dev This is the keccak256 of "eip1967.proxy.initialized" - 1
     bytes32 internal constant INITIALIZABLE_STORAGE = 0xf0c57e16840df040f15088dc2f81fe391c3923bec73e23a9662efc9c229c6a00;
+    
+    uint256 internal constant historicalBackfillApproxDoneAt = 1760630077;
 }

--- a/contracts/src/libraries/EthscriptionsRendererLib.sol
+++ b/contracts/src/libraries/EthscriptionsRendererLib.sol
@@ -1,0 +1,208 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.24;
+
+import {Base64} from "solady/utils/Base64.sol";
+import {LibString} from "solady/utils/LibString.sol";
+import {Ethscriptions} from "../Ethscriptions.sol";
+
+/// @title EthscriptionsRendererLib
+/// @notice Library for rendering Ethscription metadata and media URIs
+/// @dev Contains all token URI generation, media handling, and metadata formatting logic
+library EthscriptionsRendererLib {
+    using LibString for *;
+
+    /// @notice Build attributes JSON array from ethscription data
+    /// @param etsc Storage pointer to the ethscription
+    /// @param txHash The transaction hash of the ethscription
+    /// @return JSON string of attributes array
+    function buildAttributes(Ethscriptions.Ethscription storage etsc, bytes32 txHash)
+        internal
+        view
+        returns (string memory)
+    {
+        // Build in chunks to avoid stack too deep
+        string memory part1 = string.concat(
+            '[{"trait_type":"Transaction Hash","value":"',
+            uint256(txHash).toHexString(),
+            '"},{"trait_type":"Ethscription Number","display_type":"number","value":',
+            etsc.ethscriptionNumber.toString(),
+            '},{"trait_type":"Creator","value":"',
+            etsc.creator.toHexString(),
+            '"},{"trait_type":"Initial Owner","value":"',
+            etsc.initialOwner.toHexString()
+        );
+
+        string memory part2 = string.concat(
+            '"},{"trait_type":"Content SHA","value":"',
+            uint256(etsc.content.contentSha).toHexString(),
+            '"},{"trait_type":"MIME Type","value":"',
+            etsc.content.mimetype.escapeJSON(),
+            '"},{"trait_type":"Media Type","value":"',
+            etsc.content.mediaType.escapeJSON(),
+            '"},{"trait_type":"MIME Subtype","value":"',
+            etsc.content.mimeSubtype.escapeJSON()
+        );
+
+        string memory part3 = string.concat(
+            '"},{"trait_type":"ESIP-6","value":"',
+            etsc.content.esip6 ? "true" : "false",
+            '"},{"trait_type":"L1 Block Number","display_type":"number","value":',
+            uint256(etsc.l1BlockNumber).toString(),
+            '},{"trait_type":"L2 Block Number","display_type":"number","value":',
+            uint256(etsc.l2BlockNumber).toString(),
+            '},{"trait_type":"Created At","display_type":"date","value":',
+            etsc.createdAt.toString(),
+            '}]'
+        );
+
+        return string.concat(part1, part2, part3);
+    }
+
+    /// @notice Generate the media URI for an ethscription
+    /// @param etsc Storage pointer to the ethscription
+    /// @param content The content bytes
+    /// @return mediaType Either "image" or "animation_url"
+    /// @return mediaUri The data URI for the media
+    function getMediaUri(Ethscriptions.Ethscription storage etsc, bytes memory content)
+        internal
+        view
+        returns (string memory mediaType, string memory mediaUri)
+    {
+        if (etsc.content.mimetype.startsWith("image/")) {
+            // Image content: wrap in SVG for pixel-perfect rendering
+            string memory imageDataUri = constructDataURI(etsc.content.mimetype, content);
+            string memory svg = wrapImageInSVG(imageDataUri);
+            mediaUri = constructDataURI("image/svg+xml", bytes(svg));
+            return ("image", mediaUri);
+        } else {
+            // Non-image content: use animation_url
+            if (etsc.content.mimetype.startsWith("video/") ||
+                etsc.content.mimetype.startsWith("audio/") ||
+                etsc.content.mimetype.eq("text/html")) {
+                // Video, audio, and HTML pass through directly as data URIs
+                mediaUri = constructDataURI(etsc.content.mimetype, content);
+            } else {
+                // Everything else (text/plain, application/json, etc.) uses the HTML viewer
+                mediaUri = createTextViewerDataURI(etsc.content.mimetype, content);
+            }
+            return ("animation_url", mediaUri);
+        }
+    }
+
+    /// @notice Build complete token URI JSON
+    /// @param etsc Storage pointer to the ethscription
+    /// @param txHash The transaction hash of the ethscription
+    /// @param content The content bytes
+    /// @return The complete base64-encoded data URI
+    function buildTokenURI(
+        Ethscriptions.Ethscription storage etsc,
+        bytes32 txHash,
+        bytes memory content
+    ) internal view returns (string memory) {
+        // Get media URI
+        (string memory mediaType, string memory mediaUri) = getMediaUri(etsc, content);
+
+        // Build attributes
+        string memory attributes = buildAttributes(etsc, txHash);
+
+        // Build JSON
+        string memory json = string.concat(
+            '{"name":"Ethscription #',
+            etsc.ethscriptionNumber.toString(),
+            '","description":"Ethscription #',
+            etsc.ethscriptionNumber.toString(),
+            ' created by ',
+            etsc.creator.toHexString(),
+            '","',
+            mediaType,
+            '":"',
+            mediaUri.escapeJSON(),
+            '","attributes":',
+            attributes,
+            '}'
+        );
+
+        return string.concat(
+            "data:application/json;base64,",
+            Base64.encode(bytes(json))
+        );
+    }
+
+    /// @notice Construct a base64-encoded data URI
+    /// @param mimetype The MIME type
+    /// @param content The content bytes
+    /// @return The complete data URI
+    function constructDataURI(string memory mimetype, bytes memory content)
+        internal
+        pure
+        returns (string memory)
+    {
+        return string.concat(
+            "data:",
+            mimetype,
+            ";base64,",
+            Base64.encode(content)
+        );
+    }
+
+    /// @notice Wrap an image in SVG for pixel-perfect rendering
+    /// @param imageDataUri The image data URI to wrap
+    /// @return The SVG markup
+    function wrapImageInSVG(string memory imageDataUri)
+        internal
+        pure
+        returns (string memory)
+    {
+        // SVG wrapper that enforces pixelated/nearest-neighbor scaling for pixel art
+        return string.concat(
+            '<svg width="1200" height="1200" viewBox="0 0 1200 1200" version="1.2" xmlns="http://www.w3.org/2000/svg" style="background-image:url(',
+            imageDataUri,
+            ');background-repeat:no-repeat;background-size:contain;background-position:center;image-rendering:-webkit-optimize-contrast;image-rendering:-moz-crisp-edges;image-rendering:pixelated;"></svg>'
+        );
+    }
+
+    /// @notice Create an HTML viewer data URI for text content
+    /// @param mimetype The MIME type of the content
+    /// @param content The content bytes
+    /// @return The HTML viewer data URI
+    function createTextViewerDataURI(string memory mimetype, bytes memory content)
+        internal
+        pure
+        returns (string memory)
+    {
+        // Base64 encode the content for embedding in HTML
+        string memory encodedContent = Base64.encode(content);
+
+        // Generate HTML with embedded content
+        string memory html = generateTextViewerHTML(encodedContent, mimetype);
+
+        // Return as base64-encoded HTML data URI
+        return constructDataURI("text/html", bytes(html));
+    }
+
+    /// @notice Generate minimal HTML viewer for text content
+    /// @param encodedPayload Base64-encoded content
+    /// @param mimetype The MIME type
+    /// @return The complete HTML string
+    function generateTextViewerHTML(string memory encodedPayload, string memory mimetype)
+        internal
+        pure
+        returns (string memory)
+    {
+        // Ultra-minimal HTML with inline styles optimized for iframe display
+        return string.concat(
+            '<!DOCTYPE html><html><head><meta charset="utf-8"/><meta name="viewport" content="width=device-width,initial-scale=1"/>',
+            '<style>*{box-sizing:border-box;margin:0;padding:0;border:0}body{padding:6dvw;background:#0b0b0c;color:#f5f5f5;font-family:monospace;display:flex;justify-content:center;align-items:center;min-height:100dvh;overflow:hidden}',
+            'pre{white-space:pre-wrap;word-break:break-word;overflow-wrap:anywhere;line-height:1.4;font-size:14px}</style></head>',
+            '<body><pre id="o"></pre><script>',
+            'const p="', encodedPayload, '";',
+            'const m="', mimetype.escapeJSON(), '";',
+            'function d(b){try{return decodeURIComponent(atob(b).split("").map(c=>"%"+("00"+c.charCodeAt(0).toString(16)).slice(-2)).join(""))}catch{return null}}',
+            'const r=d(p);let t="";',
+            'if(r!==null){t=r;try{const j=JSON.parse(r);t=JSON.stringify(j,null,2)}catch{}}',
+            'else{t="data:"+m+";base64,"+p}',
+            'document.getElementById("o").textContent=t||"(empty)";',
+            '</script></body></html>'
+        );
+    }
+}

--- a/contracts/src/libraries/SSTORE2ChunkedStorageLib.sol
+++ b/contracts/src/libraries/SSTORE2ChunkedStorageLib.sol
@@ -1,0 +1,105 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.24;
+
+import {SSTORE2} from "solady/utils/SSTORE2.sol";
+
+/// @title SSTORE2ChunkedStorageLib
+/// @notice Generic library for storing and reading large content using chunked SSTORE2
+/// @dev Handles content larger than SSTORE2's single-contract limit by splitting into chunks
+library SSTORE2ChunkedStorageLib {
+    /// @dev Maximum chunk size for SSTORE2 (24KB - 1 byte for STOP opcode)
+    uint256 internal constant CHUNK_SIZE = 24575;
+
+    /// @notice Store content in chunked SSTORE2 contracts
+    /// @param content The content to store
+    /// @return pointers Array of SSTORE2 contract addresses containing the chunks
+    function store(bytes calldata content)
+        internal
+        returns (address[] memory pointers)
+    {
+        uint256 contentLength = content.length;
+
+        if (contentLength == 0) {
+            // Return empty array for empty content
+            return pointers;
+        }
+
+        // Calculate number of chunks needed
+        uint256 numChunks = (contentLength + CHUNK_SIZE - 1) / CHUNK_SIZE;
+        pointers = new address[](numChunks);
+
+        // Split content into chunks and store each via SSTORE2
+        for (uint256 i = 0; i < numChunks; i++) {
+            uint256 start = i * CHUNK_SIZE;
+            uint256 end = start + CHUNK_SIZE;
+            if (end > contentLength) {
+                end = contentLength;
+            }
+
+            // Use calldata slicing for efficiency
+            bytes calldata chunk = content[start:end];
+
+            // Store chunk and save pointer
+            pointers[i] = SSTORE2.write(chunk);
+        }
+
+        return pointers;
+    }
+
+    /// @notice Read content from storage array of SSTORE2 pointers
+    /// @param pointers Storage array of SSTORE2 contract addresses
+    /// @return content The concatenated content from all chunks
+    function read(address[] storage pointers)
+        internal
+        view
+        returns (bytes memory content)
+    {
+        uint256 length = pointers.length;
+
+        if (length == 0) {
+            return "";
+        }
+
+        if (length == 1) {
+            return SSTORE2.read(pointers[0]);
+        }
+
+        // Multiple chunks - use assembly for efficient concatenation
+        assembly {
+            // Calculate total size needed
+            let totalSize := 0
+            let pointersSlot := pointers.slot
+            let pointersLength := sload(pointersSlot)
+            let dataOffset := 0x01 // SSTORE2 data starts after STOP opcode
+
+            for { let i := 0 } lt(i, pointersLength) { i := add(i, 1) } {
+                // Storage array elements are at keccak256(slot) + index
+                mstore(0, pointersSlot)
+                let elementSlot := add(keccak256(0, 0x20), i)
+                let pointer := sload(elementSlot)
+                let codeSize := extcodesize(pointer)
+                totalSize := add(totalSize, sub(codeSize, dataOffset))
+            }
+
+            // Allocate result buffer
+            content := mload(0x40)
+            let contentPtr := add(content, 0x20)
+
+            // Copy data from each pointer
+            let currentOffset := 0
+            for { let i := 0 } lt(i, pointersLength) { i := add(i, 1) } {
+                mstore(0, pointersSlot)
+                let elementSlot := add(keccak256(0, 0x20), i)
+                let pointer := sload(elementSlot)
+                let codeSize := extcodesize(pointer)
+                let chunkSize := sub(codeSize, dataOffset)
+                extcodecopy(pointer, add(contentPtr, currentOffset), dataOffset, chunkSize)
+                currentOffset := add(currentOffset, chunkSize)
+            }
+
+            // Update length and free memory pointer with proper alignment
+            mstore(content, totalSize)
+            mstore(0x40, and(add(add(contentPtr, totalSize), 0x1f), not(0x1f)))
+        }
+    }
+}

--- a/contracts/test/CollectionsManager.t.sol
+++ b/contracts/test/CollectionsManager.t.sol
@@ -50,7 +50,7 @@ contract CollectionsManagerTest is TestSetup {
             mimeSubtype: "json",
             esip6: false,
             protocolParams: Ethscriptions.ProtocolParams({
-                protocol: "collections",
+                protocolName: "collections",
                 operation: "create_collection",
                 data: abi.encode(metadata)
             })
@@ -132,7 +132,7 @@ contract CollectionsManagerTest is TestSetup {
             mimeSubtype: "json",
             esip6: false,
             protocolParams: Ethscriptions.ProtocolParams({
-                protocol: "collections",
+                protocolName: "collections",
                 operation: "add_items_batch",
                 data: abi.encode(addOp)
             })
@@ -228,7 +228,7 @@ contract CollectionsManagerTest is TestSetup {
             mimeSubtype: "json",
             esip6: false,
             protocolParams: Ethscriptions.ProtocolParams({
-                protocol: "collections",
+                protocolName: "collections",
                 operation: "remove_items",
                 data: abi.encode(removeOp)
             })
@@ -271,7 +271,7 @@ contract CollectionsManagerTest is TestSetup {
             mimeSubtype: "plain",
             esip6: false,
             protocolParams: Ethscriptions.ProtocolParams({
-                protocol: "collections",
+                protocolName: "collections",
                 operation: "remove_items",
                 data: abi.encode(removeOp)
             })
@@ -335,7 +335,7 @@ contract CollectionsManagerTest is TestSetup {
                 mimeSubtype: "plain",
                 esip6: false,
                 protocolParams: Ethscriptions.ProtocolParams({
-                    protocol: "collections",
+                    protocolName: "collections",
                     operation: "add_items_batch",
                     data: abi.encode(addOp)
                 })
@@ -412,7 +412,7 @@ contract CollectionsManagerTest is TestSetup {
             mimeSubtype: "png",
             esip6: false,
             protocolParams: Ethscriptions.ProtocolParams({
-                protocol: "collections",
+                protocolName: "collections",
                 operation: "add_items_batch",
                 data: abi.encode(addOp)
             })
@@ -483,7 +483,7 @@ contract CollectionsManagerTest is TestSetup {
             mimeSubtype: "plain",
             esip6: false,
             protocolParams: Ethscriptions.ProtocolParams({
-                protocol: "collections",
+                protocolName: "collections",
                 operation: "edit_collection_item",
                 data: abi.encode(editOp)
             })
@@ -522,7 +522,7 @@ contract CollectionsManagerTest is TestSetup {
             mimeSubtype: "plain",
             esip6: false,
             protocolParams: Ethscriptions.ProtocolParams({
-                protocol: "",
+                protocolName: "",
                 operation: "",
                 data: ""
             })
@@ -560,7 +560,7 @@ contract CollectionsManagerTest is TestSetup {
             mimeSubtype: "plain",
             esip6: false,
             protocolParams: Ethscriptions.ProtocolParams({
-                protocol: "collections",
+                protocolName: "collections",
                 operation: "add_items_batch",
                 data: abi.encode(addOp)
             })
@@ -591,7 +591,7 @@ contract CollectionsManagerTest is TestSetup {
             mimeSubtype: "plain",
             esip6: false,
             protocolParams: Ethscriptions.ProtocolParams({
-                protocol: "collections",
+                protocolName: "collections",
                 operation: "edit_collection_item",
                 data: abi.encode(editOp)
             })
@@ -636,7 +636,7 @@ contract CollectionsManagerTest is TestSetup {
             mimeSubtype: "plain",
             esip6: false,
             protocolParams: Ethscriptions.ProtocolParams({
-                protocol: "collections",
+                protocolName: "collections",
                 operation: "edit_collection_item",
                 data: abi.encode(editOp)
             })
@@ -676,7 +676,7 @@ contract CollectionsManagerTest is TestSetup {
             mimeSubtype: "plain",
             esip6: false,
             protocolParams: Ethscriptions.ProtocolParams({
-                protocol: "collections",
+                protocolName: "collections",
                 operation: "edit_collection_item",
                 data: abi.encode(editOp)
             })
@@ -727,7 +727,7 @@ contract CollectionsManagerTest is TestSetup {
             mimeSubtype: "plain",
             esip6: false,
             protocolParams: Ethscriptions.ProtocolParams({
-                protocol: "collections",
+                protocolName: "collections",
                 operation: "sync_ownership",
                 data: abi.encode(COLLECTION_TX_HASH, ethscriptionIds)
             })
@@ -776,7 +776,7 @@ contract CollectionsManagerTest is TestSetup {
             mimeSubtype: "plain",
             esip6: false,
             protocolParams: Ethscriptions.ProtocolParams({
-                protocol: "collections",
+                protocolName: "collections",
                 operation: "sync_ownership",
                 data: abi.encode(COLLECTION_TX_HASH, ethscriptionIds)
             })
@@ -808,7 +808,7 @@ contract CollectionsManagerTest is TestSetup {
             mimeSubtype: "plain",
             esip6: false,
             protocolParams: Ethscriptions.ProtocolParams({
-                protocol: "collections",
+                protocolName: "collections",
                 operation: "sync_ownership",
                 data: abi.encode(COLLECTION_TX_HASH, ethscriptionIds)
             })
@@ -836,7 +836,7 @@ contract CollectionsManagerTest is TestSetup {
             mimeSubtype: "plain",
             esip6: false,
             protocolParams: Ethscriptions.ProtocolParams({
-                protocol: "collections",
+                protocolName: "collections",
                 operation: "sync_ownership",
                 data: abi.encode(fakeCollectionId, ethscriptionIds)
             })
@@ -866,7 +866,7 @@ contract CollectionsManagerTest is TestSetup {
             mimeSubtype: "plain",
             esip6: false,
             protocolParams: Ethscriptions.ProtocolParams({
-                protocol: "collections",
+                protocolName: "collections",
                 operation: "lock_collection",
                 data: abi.encode(COLLECTION_TX_HASH)
             })
@@ -897,7 +897,7 @@ contract CollectionsManagerTest is TestSetup {
             mimeSubtype: "plain",
             esip6: false,
             protocolParams: Ethscriptions.ProtocolParams({
-                protocol: "collections",
+                protocolName: "collections",
                 operation: "edit_collection_item",
                 data: abi.encode(editOp)
             })

--- a/contracts/test/CollectionsProtocol.t.sol
+++ b/contracts/test/CollectionsProtocol.t.sol
@@ -86,7 +86,7 @@ contract CollectionsProtocolTest is TestSetup {
             mimeSubtype: "json",
             esip6: false,
             protocolParams: Ethscriptions.ProtocolParams({
-                protocol: "collections",
+                protocolName: "collections",
                 operation: "create_collection",
                 data: encodedProtocolData
             })

--- a/contracts/test/ERC721Enumerable.t.sol
+++ b/contracts/test/ERC721Enumerable.t.sol
@@ -27,7 +27,7 @@ contract ERC721EnumerableTest is TestSetup {
                 mimeSubtype: "plain",
                 esip6: false,
                 protocolParams: Ethscriptions.ProtocolParams({
-                    protocol: "",
+                    protocolName: "",
                     operation: "",
                     data: ""
                 })

--- a/contracts/test/EndToEndCompression.t.sol
+++ b/contracts/test/EndToEndCompression.t.sol
@@ -58,7 +58,7 @@ contract EndToEndCompressionTest is TestSetup {
     //     //     esip6: false,
     //     //     isCompressed: isCompressed,
     //     //     protocolParams: Ethscriptions.ProtocolParams({
-    //     //         protocol: "",
+    //     //         protocolName: "",
     //     //         operation: "",
     //     //         data: ""
     //     //     })

--- a/contracts/test/EthscriptionsCompression.t.sol
+++ b/contracts/test/EthscriptionsCompression.t.sol
@@ -99,7 +99,7 @@ contract EthscriptionsCompressionTest is TestSetup {
     //         esip6: false,
     //         isCompressed: false,
     //         protocolParams: Ethscriptions.ProtocolParams({
-    //             protocol: "", operation: "", data: ""
+    //             protocolName: "", operation: "", data: ""
     //         })
     //     }));
     //     uint256 uncompressedGas = gasStart - gasleft();
@@ -117,7 +117,7 @@ contract EthscriptionsCompressionTest is TestSetup {
     //         esip6: false,
     //         isCompressed: true,
     //         protocolParams: Ethscriptions.ProtocolParams({
-    //             protocol: "", operation: "", data: ""
+    //             protocolName: "", operation: "", data: ""
     //         })
     //     }));
     //     uint256 compressedGas = gasStart - gasleft();

--- a/contracts/test/EthscriptionsFailureHandling.t.sol
+++ b/contracts/test/EthscriptionsFailureHandling.t.sol
@@ -108,7 +108,7 @@ contract EthscriptionsFailureHandlingTest is TestSetup {
             mimeSubtype: "plain",
             esip6: false,
             protocolParams: Ethscriptions.ProtocolParams({
-                protocol: "test",
+                protocolName: "test",
                 operation: "deploy",
                 data: abi.encode("TEST", uint256(1000000), uint256(100))
             })
@@ -192,7 +192,7 @@ contract EthscriptionsFailureHandlingTest is TestSetup {
             mimeSubtype: "json",
             esip6: false,
             protocolParams: Ethscriptions.ProtocolParams({
-                protocol: "test",
+                protocolName: "test",
                 operation: "deploy",
                 data: abi.encode("FAIL", uint256(1000), uint256(10))
             })

--- a/contracts/test/EthscriptionsJson.t.sol
+++ b/contracts/test/EthscriptionsJson.t.sol
@@ -2,16 +2,22 @@
 pragma solidity ^0.8.24;
 
 import "./TestSetup.sol";
+import "./EthscriptionsWithTestFunctions.sol";
 import "forge-std/StdJson.sol";
 
 contract EthscriptionsJsonTest is TestSetup {
     using stdJson for string;
 
-    Ethscriptions internal eth;
+    EthscriptionsWithTestFunctions internal eth;
 
     function setUp() public override {
         super.setUp();
-        eth = ethscriptions;
+
+        // Deploy the test version of Ethscriptions with additional test functions
+        // and replace the regular Ethscriptions at the predeploy address
+        EthscriptionsWithTestFunctions testEthscriptions = new EthscriptionsWithTestFunctions();
+        vm.etch(Predeploys.ETHSCRIPTIONS, address(testEthscriptions).code);
+        eth = EthscriptionsWithTestFunctions(Predeploys.ETHSCRIPTIONS);
     }
 
     function test_CreateAndTokenURIGas_FromJson() public {

--- a/contracts/test/EthscriptionsMultiTransfer.t.sol
+++ b/contracts/test/EthscriptionsMultiTransfer.t.sol
@@ -102,7 +102,7 @@ contract EthscriptionsMultiTransferTest is TestSetup {
 
         // Alice tries to transfer them (but owns none)
         vm.prank(alice);
-        vm.expectRevert("No successful transfers");
+        vm.expectRevert(Ethscriptions.NoSuccessfulTransfers.selector);
         ethscriptions.transferMultipleEthscriptions(hashes, charlie);
     }
 
@@ -121,7 +121,7 @@ contract EthscriptionsMultiTransferTest is TestSetup {
 
         // Verify all are owned by address(0) (null ownership, not burned)
         for (uint256 i = 0; i < 3; i++) {
-            assertEq(ethscriptions.currentOwner(hashes[i]), address(0), "Should be owned by null address");
+            assertEq(ethscriptions.ownerOf(hashes[i]), address(0), "Should be owned by null address");
         }
     }
 
@@ -226,7 +226,8 @@ contract EthscriptionsMultiTransferTest is TestSetup {
         string memory json = string(decodedJson);
 
         // Check all expected attributes
-        string[11] memory expectedTraits = [
+        string[12] memory expectedTraits = [
+            "Transaction Hash",
             "Ethscription Number",
             "Creator",
             "Initial Owner",

--- a/contracts/test/EthscriptionsNullOwnership.t.sol
+++ b/contracts/test/EthscriptionsNullOwnership.t.sol
@@ -22,15 +22,16 @@ contract EthscriptionsNullOwnershipTest is TestSetup {
         );
 
         // Expect only one EthscriptionCreated event (no EthscriptionTransferred since from == address(0))
+        bytes32 contentUriHash = sha256(bytes("data:text/plain,Null owned")); // Full data URI hash
         bytes32 contentSha = sha256(bytes("Null owned")); // Raw content, not data URI
         vm.expectEmit(true, true, true, true);
         emit Ethscriptions.EthscriptionCreated(
             txHash,
             alice, // creator
             address(0), // initialOwner
+            contentUriHash,
             contentSha,
-            11, // ethscription number (after 10 genesis)
-            1 // pointerCount (content stored once)
+            11 // ethscription number (after 10 genesis)
         );
 
         // Should NOT emit EthscriptionTransferred for mint
@@ -41,7 +42,7 @@ contract EthscriptionsNullOwnershipTest is TestSetup {
 
         // Verify ownership
         assertEq(ethscriptions.ownerOf(tokenId), address(0), "Should be owned by null address");
-        assertEq(ethscriptions.currentOwner(txHash), address(0), "currentOwner should return null address");
+        assertEq(ethscriptions.ownerOf(txHash), address(0), "ownerOf should return null address");
 
         // Verify ethscription data
         Ethscriptions.Ethscription memory etsc = ethscriptions.getEthscription(txHash);
@@ -82,7 +83,7 @@ contract EthscriptionsNullOwnershipTest is TestSetup {
 
         // Verify ownership changed
         assertEq(ethscriptions.ownerOf(tokenId), address(0), "Should be owned by null address");
-        assertEq(ethscriptions.currentOwner(txHash), address(0), "currentOwner should return null address");
+        assertEq(ethscriptions.ownerOf(txHash), address(0), "ownerOf should return null address");
 
         // Verify previousOwner updated
         Ethscriptions.Ethscription memory etsc = ethscriptions.getEthscription(txHash);

--- a/contracts/test/EthscriptionsProver.t.sol
+++ b/contracts/test/EthscriptionsProver.t.sol
@@ -16,7 +16,7 @@ contract EthscriptionsProverTest is TestSetup {
     function setUp() public override {
         super.setUp();
 
-        vm.warp(1760630077);
+        vm.warp(Constants.historicalBackfillApproxDoneAt);
 
         // Create a test ethscription with alice as creator
         vm.startPrank(alice);

--- a/contracts/test/EthscriptionsToken.t.sol
+++ b/contracts/test/EthscriptionsToken.t.sol
@@ -55,7 +55,7 @@ contract EthscriptionsTokenTest is TestSetup {
             mimeSubtype: "plain",
             esip6: false,
             protocolParams: Ethscriptions.ProtocolParams({
-                protocol: protocol,
+                protocolName: protocol,
                 operation: operation,
                 data: data
             })

--- a/contracts/test/EthscriptionsToken.t.sol
+++ b/contracts/test/EthscriptionsToken.t.sol
@@ -304,7 +304,7 @@ contract EthscriptionsTokenTest is TestSetup {
         
         // Bob tries to transfer tokens directly (not via NFT) - should revert
         vm.prank(bob);
-        vm.expectRevert("Transfers only allowed via Ethscriptions NFT");
+        vm.expectRevert(EthscriptionsERC20.TransfersOnlyViaEthscriptions.selector);
         token.transfer(charlie, 500);
     }
     

--- a/contracts/test/EthscriptionsTokenParams.t.sol
+++ b/contracts/test/EthscriptionsTokenParams.t.sol
@@ -28,7 +28,7 @@ contract EthscriptionsTokenParamsTest is TestSetup {
             mimeSubtype: "plain",
             esip6: false,
             protocolParams: Ethscriptions.ProtocolParams({
-                protocol: "erc-20",
+                protocolName: "erc-20",
                 operation: "deploy",
                 data: abi.encode(deployOp)
             })
@@ -68,7 +68,7 @@ contract EthscriptionsTokenParamsTest is TestSetup {
             mimeSubtype: "plain",
             esip6: false,
             protocolParams: Ethscriptions.ProtocolParams({
-                protocol: "erc-20",
+                protocolName: "erc-20",
                 operation: "mint",
                 data: abi.encode(mintOp)
             })
@@ -97,7 +97,7 @@ contract EthscriptionsTokenParamsTest is TestSetup {
             mimeSubtype: "plain",
             esip6: false,
             protocolParams: Ethscriptions.ProtocolParams({
-                protocol: "",
+                protocolName: "",
                 operation: "",
                 data: ""
             })
@@ -132,7 +132,7 @@ contract EthscriptionsTokenParamsTest is TestSetup {
             mimeSubtype: "json",
             esip6: false,
             protocolParams: Ethscriptions.ProtocolParams({
-                protocol: "erc-20",
+                protocolName: "erc-20",
                 operation: "deploy",
                 data: abi.encode(deployOp)
             })
@@ -160,7 +160,7 @@ contract EthscriptionsTokenParamsTest is TestSetup {
             mimeSubtype: "json",
             esip6: false,
             protocolParams: Ethscriptions.ProtocolParams({
-                protocol: "erc-20",
+                protocolName: "erc-20",
                 operation: "mint",
                 data: abi.encode(mintOp)
             })

--- a/contracts/test/EthscriptionsTransferForPreviousOwner.t.sol
+++ b/contracts/test/EthscriptionsTransferForPreviousOwner.t.sol
@@ -46,13 +46,13 @@ contract EthscriptionsTransferForPreviousOwnerTest is TestSetup {
         );
         
         // Verify ownership and previous owner updated
-        assertEq(eth.currentOwner(txHash), thirdOwner);
+        assertEq(eth.ownerOf(txHash), thirdOwner);
         etsc = eth.getEthscription(txHash);
         assertEq(etsc.previousOwner, newOwner);
         
         // Test that wrong previous owner fails
         vm.prank(thirdOwner);
-        vm.expectRevert("Previous owner mismatch");
+        vm.expectRevert(Ethscriptions.PreviousOwnerMismatch.selector);
         eth.transferEthscriptionForPreviousOwner(
             address(0x5),
             txHash,

--- a/contracts/test/EthscriptionsWithContent.t.sol
+++ b/contracts/test/EthscriptionsWithContent.t.sol
@@ -24,7 +24,7 @@ contract EthscriptionsWithContentTest is TestSetup {
             mimeSubtype: "plain",
             esip6: false,
             protocolParams: Ethscriptions.ProtocolParams({
-                protocol: "",
+                protocolName: "",
                 operation: "",
                 data: ""
             })
@@ -106,7 +106,7 @@ contract EthscriptionsWithContentTest is TestSetup {
             mimeSubtype: "octet-stream",
             esip6: false,
             protocolParams: Ethscriptions.ProtocolParams({
-                protocol: "",
+                protocolName: "",
                 operation: "",
                 data: ""
             })

--- a/contracts/test/EthscriptionsWithTestFunctions.sol
+++ b/contracts/test/EthscriptionsWithTestFunctions.sol
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.24;
+
+import "../src/Ethscriptions.sol";
+import {SSTORE2} from "solady/utils/SSTORE2.sol";
+
+/// @title EthscriptionsWithTestFunctions
+/// @notice Test contract that extends Ethscriptions with additional functions for testing
+/// @dev These functions expose internal storage details useful for tests but not needed in production
+/// @dev Usage: Deploy this contract instead of regular Ethscriptions in test setup, then cast to this type
+contract EthscriptionsWithTestFunctions is Ethscriptions {
+
+    /// @notice Get the number of content pointers for an ethscription
+    /// @dev Test-only function to inspect storage chunks
+    function getContentPointerCount(bytes32 transactionHash) external view requireExists(transactionHash) returns (uint256) {
+        Ethscription storage etsc = ethscriptions[transactionHash];
+        return contentPointersBySha[etsc.content.contentSha].length;
+    }
+
+    /// @notice Get all content pointers for an ethscription
+    /// @dev Test-only function to inspect SSTORE2 addresses
+    function getContentPointers(bytes32 transactionHash) external view requireExists(transactionHash) returns (address[] memory) {
+        Ethscription storage etsc = ethscriptions[transactionHash];
+        return contentPointersBySha[etsc.content.contentSha];
+    }
+
+    /// @notice Read a specific chunk of content
+    /// @dev Test-only function to read individual SSTORE2 chunks
+    /// @param transactionHash The ethscription transaction hash
+    /// @param index The chunk index to read
+    /// @return The chunk data
+    function readChunk(bytes32 transactionHash, uint256 index) external view requireExists(transactionHash) returns (bytes memory) {
+        Ethscription storage etsc = ethscriptions[transactionHash];
+        address[] storage pointers = contentPointersBySha[etsc.content.contentSha];
+        require(index < pointers.length, "Chunk index out of bounds");
+        return SSTORE2.read(pointers[index]);
+    }
+}

--- a/contracts/test/ProtocolRegistration.t.sol
+++ b/contracts/test/ProtocolRegistration.t.sol
@@ -34,7 +34,7 @@ contract ProtocolRegistrationTest is TestSetup {
         assertEq(ethscriptions.protocolHandlers("test-protocol"), address(mockHandler1));
 
         // Try to register the same protocol again (should revert)
-        vm.expectRevert(bytes("Protocol already registered"));
+        vm.expectRevert(Ethscriptions.ProtocolAlreadyRegistered.selector);
         vm.prank(Predeploys.DEPOSITOR_ACCOUNT);
         ethscriptions.registerProtocol("test-protocol", address(mockHandler2));
 
@@ -50,7 +50,7 @@ contract ProtocolRegistrationTest is TestSetup {
         ethscriptions.registerProtocol("concurrent-test", address(mockHandler1));
 
         // Second registration with different handler fails
-        vm.expectRevert(bytes("Protocol already registered"));
+        vm.expectRevert(Ethscriptions.ProtocolAlreadyRegistered.selector);
         vm.prank(Predeploys.DEPOSITOR_ACCOUNT);
         ethscriptions.registerProtocol("concurrent-test", address(mockHandler2));
 
@@ -78,7 +78,7 @@ contract ProtocolRegistrationTest is TestSetup {
     /// @notice Test that protocol registration is restricted to authorized accounts
     function testUnauthorizedCannotRegisterProtocol() public {
         // Try to register from unauthorized account (should revert)
-        vm.expectRevert(bytes("Only depositor can register protocols"));
+        vm.expectRevert(Ethscriptions.OnlyDepositor.selector);
         vm.prank(alice);
         ethscriptions.registerProtocol("unauthorized", address(mockHandler1));
 
@@ -88,7 +88,7 @@ contract ProtocolRegistrationTest is TestSetup {
 
     /// @notice Test registration with zero address handler
     function testCannotRegisterZeroAddressHandler() public {
-        vm.expectRevert(bytes("Invalid handler address"));
+        vm.expectRevert(Ethscriptions.InvalidHandler.selector);
         vm.prank(Predeploys.DEPOSITOR_ACCOUNT);
         ethscriptions.registerProtocol("zero-handler", address(0));
     }
@@ -121,7 +121,7 @@ contract ProtocolRegistrationTest is TestSetup {
             mimeSubtype: "json",
             esip6: false,
             protocolParams: Ethscriptions.ProtocolParams({
-                protocol: "mock-protocol",
+                protocolName: "mock-protocol",
                 operation: "test",
                 data: abi.encode(uint256(42))
             })
@@ -167,7 +167,7 @@ contract ProtocolRegistrationTest is TestSetup {
             mimeSubtype: "json",
             esip6: false,
             protocolParams: Ethscriptions.ProtocolParams({
-                protocol: "unregistered",
+                protocolName: "unregistered",
                 operation: "test",
                 data: ""
             })

--- a/contracts/test/TestImageSVGWrapper.t.sol
+++ b/contracts/test/TestImageSVGWrapper.t.sol
@@ -26,7 +26,7 @@ contract TestImageSVGWrapper is TestSetup {
             mimeSubtype: "png",
             esip6: false,
             protocolParams: Ethscriptions.ProtocolParams({
-                protocol: "",
+                protocolName: "",
                 operation: "",
                 data: ""
             })

--- a/contracts/test/TestSetup.sol
+++ b/contracts/test/TestSetup.sol
@@ -158,7 +158,7 @@ abstract contract TestSetup is Test {
             mimeSubtype: mimeSubtype,
             esip6: esip6,
             protocolParams: Ethscriptions.ProtocolParams({
-                protocol: "",
+                protocolName: "",
                 operation: "",
                 data: ""
             })


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Refactors Ethscriptions to use chunked storage and a renderer lib, updates events and protocol params, tightens prover/manager logic, and aligns scripts/tests and Ruby decoders with the new interfaces.
> 
> - **Contracts (Ethscriptions)**:
>   - Storage: Replace `contentBySha` with `contentPointersBySha` via `SSTORE2ChunkedStorageLib`; dedupe by `firstEthscriptionByContentUri`.
>   - Rendering: Move token URI/media building to `EthscriptionsRendererLib`.
>   - API: `ProtocolParams.protocol` -> `protocolName`; track with `protocolOf`; add `ownerOf(bytes32)` and `exists(uint256)`.
>   - Events: `EthscriptionCreated` adds `contentUriHash` and drops `pointerCount`; `ProtocolHandlerSuccess` includes `bytes returnData`.
>   - Errors/logic: New custom errors (e.g., `NoSuccessfulTransfers`, `OnlyDepositor`, etc.); use `Constants.historicalBackfillApproxDoneAt`; minor L1 block var rename.
> - **Prover/L1**:
>   - Access control via custom errors; use `ethscriptions.ownerOf(bytes32)`; trigger flush using `Constants.historicalBackfillApproxDoneAt`.
> - **ERC20 Token**:
>   - Add explicit errors; make `initialize` external; restrict user flows with specific reverts; docs cleanup.
> - **TokenManager**:
>   - Add custom errors; validate/mint/deploy with strict checks; consolidate tick key derivation; expand views; simplify transfer notifications.
> - **Genesis Script**:
>   - Use `firstEthscriptionByContentUri` logic; rename protocol param to `protocolName` in JSON import.
> - **Libraries**:
>   - Add `Constants.historicalBackfillApproxDoneAt`, `EthscriptionsRendererLib`, and `SSTORE2ChunkedStorageLib`.
> - **Infra/Tools**:
>   - Update Ruby decoders/signatures for new `EthscriptionCreated` and `ProtocolHandlerSuccess`.
> - **Tests**:
>   - Update for new events/errors/APIs; add `EthscriptionsWithTestFunctions` for chunk introspection; adjust expectations (e.g., `ownerOf(bytes32)`, new error selectors).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e28f4962ee52be7c6cfa49f4f208bf442b472e9e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->