### PR TITLE
Optimize contracts

### DIFF
--- a/contracts/script/L2Genesis.s.sol
+++ b/contracts/script/L2Genesis.s.sol
@@ -44,22 +44,23 @@ contract GenesisEthscriptions is Ethscriptions {
 
         // Set all values including genesis-specific ones
         ethscriptions[params.transactionHash] = Ethscription({
-            content: ContentInfo({
-                contentUriHash: params.contentUriHash,
-                contentSha: contentSha,
-                mimetype: params.mimetype,
-                mediaType: params.mediaType,
-                mimeSubtype: params.mimeSubtype,
-                esip6: params.esip6
-            }),
+            // Fixed-size fields
+            contentUriHash: params.contentUriHash,
+            contentSha: contentSha,
+            l1BlockHash: l1BlockHash,
+            // Packed slot 3
             creator: creator,
+            createdAt: uint48(createdAt),
+            l1BlockNumber: uint48(l1BlockNumber),
+            // Dynamic field
+            mimetype: params.mimetype,
+            // Packed slot N
             initialOwner: params.initialOwner,
+            ethscriptionNumber: uint48(totalSupply()),
+            esip6: params.esip6,
+            // Packed slot N+1
             previousOwner: creator,
-            ethscriptionNumber: totalSupply(),
-            createdAt: createdAt,
-            l1BlockNumber: l1BlockNumber,
-            l2BlockNumber: 0,  // Genesis ethscriptions have no L2 block
-            l1BlockHash: l1BlockHash
+            l2BlockNumber: 0  // Genesis ethscriptions have no L2 block
         });
 
         // Use ethscription number as token ID
@@ -337,8 +338,6 @@ contract L2Genesis is Script {
         params.initialOwner = initialOwner;
         params.content = vm.parseJsonBytes(json, string.concat(basePath, ".content"));
         params.mimetype = vm.parseJsonString(json, string.concat(basePath, ".mimetype"));
-        params.mediaType = vm.parseJsonString(json, string.concat(basePath, ".media_type"));
-        params.mimeSubtype = vm.parseJsonString(json, string.concat(basePath, ".mime_subtype"));
         params.esip6 = vm.parseJsonBool(json, string.concat(basePath, ".esip6"));
         params.protocolParams = Ethscriptions.ProtocolParams({
             protocolName: "",

--- a/contracts/script/TestTokenUri.s.sol
+++ b/contracts/script/TestTokenUri.s.sol
@@ -22,8 +22,6 @@ contract TestTokenUri is Script {
             initialOwner: address(0x1111),
             content: bytes("Hello World!"),
             mimetype: "text/plain",
-            mediaType: "text",
-            mimeSubtype: "plain",
             esip6: false,
             protocolParams: Ethscriptions.ProtocolParams("", "", "")
         }));
@@ -36,8 +34,6 @@ contract TestTokenUri is Script {
             initialOwner: address(0x2222),
             content: bytes('{"p":"erc-20","op":"mint","tick":"test","amt":"1000"}'),
             mimetype: "application/json",
-            mediaType: "application",
-            mimeSubtype: "json",
             esip6: false,
             protocolParams: Ethscriptions.ProtocolParams("", "", "")
         }));
@@ -50,8 +46,6 @@ contract TestTokenUri is Script {
             initialOwner: address(0x3333),
             content: bytes('<html><body style="background:linear-gradient(45deg,#ff006e,#8338ec);color:white;font-family:monospace;display:flex;align-items:center;justify-content:center;height:100vh;margin:0"><h1>Ethscriptions Rule!</h1></body></html>'),
             mimetype: "text/html",
-            mediaType: "text",
-            mimeSubtype: "html",
             esip6: false,
             protocolParams: Ethscriptions.ProtocolParams("", "", "")
         }));
@@ -65,8 +59,6 @@ contract TestTokenUri is Script {
             initialOwner: address(0x4444),
             content: redPixelPng,
             mimetype: "image/png",
-            mediaType: "image",
-            mimeSubtype: "png",
             esip6: false,
             protocolParams: Ethscriptions.ProtocolParams("", "", "")
         }));
@@ -79,8 +71,6 @@ contract TestTokenUri is Script {
             initialOwner: address(0x5555),
             content: bytes("body { background: #000; color: #0f0; font-family: 'Courier New'; }"),
             mimetype: "text/css",
-            mediaType: "text",
-            mimeSubtype: "css",
             esip6: false,
             protocolParams: Ethscriptions.ProtocolParams("", "", "")
         }));

--- a/contracts/src/EthscriptionsProver.sol
+++ b/contracts/src/EthscriptionsProver.sol
@@ -19,10 +19,10 @@ contract EthscriptionsProver {
 
     /// @notice Info stored when an ethscription is queued for proving
     struct QueuedProof {
-        uint256 l2BlockNumber;
-        uint256 l2BlockTimestamp;
         bytes32 l1BlockHash;
-        uint256 l1BlockNumber;
+        uint48 l2BlockNumber;
+        uint48 l2BlockTimestamp;
+        uint48 l1BlockNumber;
     }
 
     /// @notice Struct for ethscription data proof
@@ -30,15 +30,15 @@ contract EthscriptionsProver {
         bytes32 ethscriptionTxHash;
         bytes32 contentSha;
         bytes32 contentUriHash;
+        bytes32 l1BlockHash;
         address creator;
         address currentOwner;
         address previousOwner;
-        uint256 ethscriptionNumber;
         bool esip6;
-        bytes32 l1BlockHash;
-        uint256 l1BlockNumber;
-        uint256 l2BlockNumber;
-        uint256 l2Timestamp;
+        uint48 ethscriptionNumber;
+        uint48 l1BlockNumber;
+        uint48 l2BlockNumber;
+        uint48 l2Timestamp;
     }
 
     // =============================================================
@@ -99,10 +99,10 @@ contract EthscriptionsProver {
             // Capture the L1 block hash and number at the time of queuing
             L1Block l1Block = L1Block(L1_BLOCK);
             queuedProofInfo[txHash] = QueuedProof({
-                l2BlockNumber: block.number,
-                l2BlockTimestamp: block.timestamp,
                 l1BlockHash: l1Block.hash(),
-                l1BlockNumber: l1Block.number()
+                l2BlockNumber: uint48(block.number),
+                l2BlockTimestamp: uint48(block.timestamp),
+                l1BlockNumber: uint48(l1Block.number())
             });
         }
     }
@@ -143,14 +143,14 @@ contract EthscriptionsProver {
         // Create proof struct with all ethscription data
         EthscriptionDataProof memory proof = EthscriptionDataProof({
             ethscriptionTxHash: ethscriptionTxHash,
-            contentSha: etsc.content.contentSha,
-            contentUriHash: etsc.content.contentUriHash,
+            contentSha: etsc.contentSha,
+            contentUriHash: etsc.contentUriHash,
+            l1BlockHash: proofInfo.l1BlockHash,
             creator: etsc.creator,
             currentOwner: currentOwner,
             previousOwner: etsc.previousOwner,
+            esip6: etsc.esip6,
             ethscriptionNumber: etsc.ethscriptionNumber,
-            esip6: etsc.content.esip6,
-            l1BlockHash: proofInfo.l1BlockHash,
             l1BlockNumber: proofInfo.l1BlockNumber,
             l2BlockNumber: proofInfo.l2BlockNumber,
             l2Timestamp: proofInfo.l2BlockTimestamp

--- a/contracts/src/libraries/EthscriptionsRendererLib.sol
+++ b/contracts/src/libraries/EthscriptionsRendererLib.sol
@@ -34,18 +34,11 @@ library EthscriptionsRendererLib {
 
         string memory part2 = string.concat(
             '"},{"trait_type":"Content SHA","value":"',
-            uint256(etsc.content.contentSha).toHexString(),
+            uint256(etsc.contentSha).toHexString(),
             '"},{"trait_type":"MIME Type","value":"',
-            etsc.content.mimetype.escapeJSON(),
-            '"},{"trait_type":"Media Type","value":"',
-            etsc.content.mediaType.escapeJSON(),
-            '"},{"trait_type":"MIME Subtype","value":"',
-            etsc.content.mimeSubtype.escapeJSON()
-        );
-
-        string memory part3 = string.concat(
+            etsc.mimetype.escapeJSON(),
             '"},{"trait_type":"ESIP-6","value":"',
-            etsc.content.esip6 ? "true" : "false",
+            etsc.esip6 ? "true" : "false",
             '"},{"trait_type":"L1 Block Number","display_type":"number","value":',
             uint256(etsc.l1BlockNumber).toString(),
             '},{"trait_type":"L2 Block Number","display_type":"number","value":',
@@ -55,7 +48,7 @@ library EthscriptionsRendererLib {
             '}]'
         );
 
-        return string.concat(part1, part2, part3);
+        return string.concat(part1, part2);
     }
 
     /// @notice Generate the media URI for an ethscription
@@ -68,22 +61,22 @@ library EthscriptionsRendererLib {
         view
         returns (string memory mediaType, string memory mediaUri)
     {
-        if (etsc.content.mimetype.startsWith("image/")) {
+        if (etsc.mimetype.startsWith("image/")) {
             // Image content: wrap in SVG for pixel-perfect rendering
-            string memory imageDataUri = constructDataURI(etsc.content.mimetype, content);
+            string memory imageDataUri = constructDataURI(etsc.mimetype, content);
             string memory svg = wrapImageInSVG(imageDataUri);
             mediaUri = constructDataURI("image/svg+xml", bytes(svg));
             return ("image", mediaUri);
         } else {
             // Non-image content: use animation_url
-            if (etsc.content.mimetype.startsWith("video/") ||
-                etsc.content.mimetype.startsWith("audio/") ||
-                etsc.content.mimetype.eq("text/html")) {
+            if (etsc.mimetype.startsWith("video/") ||
+                etsc.mimetype.startsWith("audio/") ||
+                etsc.mimetype.eq("text/html")) {
                 // Video, audio, and HTML pass through directly as data URIs
-                mediaUri = constructDataURI(etsc.content.mimetype, content);
+                mediaUri = constructDataURI(etsc.mimetype, content);
             } else {
                 // Everything else (text/plain, application/json, etc.) uses the HTML viewer
-                mediaUri = createTextViewerDataURI(etsc.content.mimetype, content);
+                mediaUri = createTextViewerDataURI(etsc.mimetype, content);
             }
             return ("animation_url", mediaUri);
         }

--- a/contracts/test/CollectionsManager.t.sol
+++ b/contracts/test/CollectionsManager.t.sol
@@ -46,8 +46,6 @@ contract CollectionsManagerTest is TestSetup {
             initialOwner: alice,
             content: bytes(collectionContent),
             mimetype: "application/json",
-            mediaType: "application",
-            mimeSubtype: "json",
             esip6: false,
             protocolParams: Ethscriptions.ProtocolParams({
                 protocolName: "collections",
@@ -128,8 +126,6 @@ contract CollectionsManagerTest is TestSetup {
             initialOwner: alice,
             content: bytes(itemContent),
             mimetype: "application/json",
-            mediaType: "application",
-            mimeSubtype: "json",
             esip6: false,
             protocolParams: Ethscriptions.ProtocolParams({
                 protocolName: "collections",
@@ -224,8 +220,6 @@ contract CollectionsManagerTest is TestSetup {
             initialOwner: alice,
             content: bytes(removeContent),
             mimetype: "application/json",
-            mediaType: "application",
-            mimeSubtype: "json",
             esip6: false,
             protocolParams: Ethscriptions.ProtocolParams({
                 protocolName: "collections",
@@ -267,8 +261,6 @@ contract CollectionsManagerTest is TestSetup {
             initialOwner: bob,
             content: bytes("remove"),
             mimetype: "text/plain",
-            mediaType: "text",
-            mimeSubtype: "plain",
             esip6: false,
             protocolParams: Ethscriptions.ProtocolParams({
                 protocolName: "collections",
@@ -331,8 +323,6 @@ contract CollectionsManagerTest is TestSetup {
                 initialOwner: owners[i],
                 content: abi.encodePacked("item", i),
                 mimetype: "text/plain",
-                mediaType: "text",
-                mimeSubtype: "plain",
                 esip6: false,
                 protocolParams: Ethscriptions.ProtocolParams({
                     protocolName: "collections",
@@ -408,8 +398,6 @@ contract CollectionsManagerTest is TestSetup {
             initialOwner: alice,
             content: bytes(imageContent),
             mimetype: "image/png",
-            mediaType: "image",
-            mimeSubtype: "png",
             esip6: false,
             protocolParams: Ethscriptions.ProtocolParams({
                 protocolName: "collections",
@@ -479,8 +467,6 @@ contract CollectionsManagerTest is TestSetup {
             initialOwner: alice,
             content: bytes("edit"),
             mimetype: "text/plain",
-            mediaType: "text",
-            mimeSubtype: "plain",
             esip6: false,
             protocolParams: Ethscriptions.ProtocolParams({
                 protocolName: "collections",
@@ -518,8 +504,6 @@ contract CollectionsManagerTest is TestSetup {
             initialOwner: alice,
             content: bytes("item content"),
             mimetype: "text/plain",
-            mediaType: "text",
-            mimeSubtype: "plain",
             esip6: false,
             protocolParams: Ethscriptions.ProtocolParams({
                 protocolName: "",
@@ -556,8 +540,6 @@ contract CollectionsManagerTest is TestSetup {
             initialOwner: alice,
             content: bytes("add"),
             mimetype: "text/plain",
-            mediaType: "text",
-            mimeSubtype: "plain",
             esip6: false,
             protocolParams: Ethscriptions.ProtocolParams({
                 protocolName: "collections",
@@ -587,8 +569,6 @@ contract CollectionsManagerTest is TestSetup {
             initialOwner: alice,
             content: bytes("partial-edit"),
             mimetype: "text/plain",
-            mediaType: "text",
-            mimeSubtype: "plain",
             esip6: false,
             protocolParams: Ethscriptions.ProtocolParams({
                 protocolName: "collections",
@@ -632,8 +612,6 @@ contract CollectionsManagerTest is TestSetup {
             initialOwner: bob,
             content: bytes("bad-edit"),
             mimetype: "text/plain",
-            mediaType: "text",
-            mimeSubtype: "plain",
             esip6: false,
             protocolParams: Ethscriptions.ProtocolParams({
                 protocolName: "collections",
@@ -672,8 +650,6 @@ contract CollectionsManagerTest is TestSetup {
             initialOwner: alice,
             content: bytes("no-item"),
             mimetype: "text/plain",
-            mediaType: "text",
-            mimeSubtype: "plain",
             esip6: false,
             protocolParams: Ethscriptions.ProtocolParams({
                 protocolName: "collections",
@@ -723,8 +699,6 @@ contract CollectionsManagerTest is TestSetup {
             initialOwner: charlie,
             content: bytes("sync"),
             mimetype: "text/plain",
-            mediaType: "text",
-            mimeSubtype: "plain",
             esip6: false,
             protocolParams: Ethscriptions.ProtocolParams({
                 protocolName: "collections",
@@ -772,8 +746,6 @@ contract CollectionsManagerTest is TestSetup {
             initialOwner: alice,
             content: bytes("sync-multi"),
             mimetype: "text/plain",
-            mediaType: "text",
-            mimeSubtype: "plain",
             esip6: false,
             protocolParams: Ethscriptions.ProtocolParams({
                 protocolName: "collections",
@@ -804,8 +776,6 @@ contract CollectionsManagerTest is TestSetup {
             initialOwner: alice,
             content: bytes("sync-nonexistent"),
             mimetype: "text/plain",
-            mediaType: "text",
-            mimeSubtype: "plain",
             esip6: false,
             protocolParams: Ethscriptions.ProtocolParams({
                 protocolName: "collections",
@@ -832,8 +802,6 @@ contract CollectionsManagerTest is TestSetup {
             initialOwner: alice,
             content: bytes("sync-fake"),
             mimetype: "text/plain",
-            mediaType: "text",
-            mimeSubtype: "plain",
             esip6: false,
             protocolParams: Ethscriptions.ProtocolParams({
                 protocolName: "collections",
@@ -862,8 +830,6 @@ contract CollectionsManagerTest is TestSetup {
             initialOwner: alice,
             content: bytes("lock"),
             mimetype: "text/plain",
-            mediaType: "text",
-            mimeSubtype: "plain",
             esip6: false,
             protocolParams: Ethscriptions.ProtocolParams({
                 protocolName: "collections",
@@ -893,8 +859,6 @@ contract CollectionsManagerTest is TestSetup {
             initialOwner: alice,
             content: bytes("locked-edit"),
             mimetype: "text/plain",
-            mediaType: "text",
-            mimeSubtype: "plain",
             esip6: false,
             protocolParams: Ethscriptions.ProtocolParams({
                 protocolName: "collections",

--- a/contracts/test/CollectionsProtocol.t.sol
+++ b/contracts/test/CollectionsProtocol.t.sol
@@ -82,8 +82,6 @@ contract CollectionsProtocolTest is TestSetup {
             initialOwner: alice,
             content: bytes(json),
             mimetype: "application/json",
-            mediaType: "application",
-            mimeSubtype: "json",
             esip6: false,
             protocolParams: Ethscriptions.ProtocolParams({
                 protocolName: "collections",

--- a/contracts/test/ERC721Enumerable.t.sol
+++ b/contracts/test/ERC721Enumerable.t.sol
@@ -23,8 +23,6 @@ contract ERC721EnumerableTest is TestSetup {
                 initialOwner: owner,
                 content: bytes(content),
                 mimetype: "text/plain",
-                mediaType: "text",
-                mimeSubtype: "plain",
                 esip6: false,
                 protocolParams: Ethscriptions.ProtocolParams({
                     protocolName: "",

--- a/contracts/test/EndToEndCompression.t.sol
+++ b/contracts/test/EndToEndCompression.t.sol
@@ -53,8 +53,6 @@ contract EndToEndCompressionTest is TestSetup {
     //     //     initialOwner: owner,
     //     //     contentUri: isCompressed ? compressedContent : bytes(originalContent),
     //     //     mimetype: "image/png",
-    //     //     mediaType: "image",
-    //     //     mimeSubtype: "png",
     //     //     esip6: false,
     //     //     isCompressed: isCompressed,
     //     //     protocolParams: Ethscriptions.ProtocolParams({

--- a/contracts/test/EthscriptionsCompression.t.sol
+++ b/contracts/test/EthscriptionsCompression.t.sol
@@ -94,8 +94,6 @@ contract EthscriptionsCompressionTest is TestSetup {
     //         initialOwner: owner,
     //         contentUri: originalContent,
     //         mimetype: "image/png",
-    //         mediaType: "image",
-    //         mimeSubtype: "png",
     //         esip6: false,
     //         isCompressed: false,
     //         protocolParams: Ethscriptions.ProtocolParams({
@@ -112,8 +110,6 @@ contract EthscriptionsCompressionTest is TestSetup {
     //         initialOwner: owner,
     //         contentUri: compressedContent,
     //         mimetype: "image/png",
-    //         mediaType: "image",
-    //         mimeSubtype: "png",
     //         esip6: false,
     //         isCompressed: true,
     //         protocolParams: Ethscriptions.ProtocolParams({

--- a/contracts/test/EthscriptionsFailureHandling.t.sol
+++ b/contracts/test/EthscriptionsFailureHandling.t.sol
@@ -104,8 +104,6 @@ contract EthscriptionsFailureHandlingTest is TestSetup {
             initialOwner: address(this),
             content: bytes("Hello World with failing token manager"),
             mimetype: "text/plain",
-            mediaType: "text",
-            mimeSubtype: "plain",
             esip6: false,
             protocolParams: Ethscriptions.ProtocolParams({
                 protocolName: "test",
@@ -188,8 +186,6 @@ contract EthscriptionsFailureHandlingTest is TestSetup {
             initialOwner: address(this),
             content: bytes("{\"p\":\"test\",\"op\":\"deploy\",\"tick\":\"FAIL\",\"max\":\"1000\",\"lim\":\"10\"}"),
             mimetype: "application/json",
-            mediaType: "application",
-            mimeSubtype: "json",
             esip6: false,
             protocolParams: Ethscriptions.ProtocolParams({
                 protocolName: "test",

--- a/contracts/test/EthscriptionsMultiTransfer.t.sol
+++ b/contracts/test/EthscriptionsMultiTransfer.t.sol
@@ -226,15 +226,13 @@ contract EthscriptionsMultiTransferTest is TestSetup {
         string memory json = string(decodedJson);
 
         // Check all expected attributes
-        string[12] memory expectedTraits = [
+        string[10] memory expectedTraits = [
             "Transaction Hash",
             "Ethscription Number",
             "Creator",
             "Initial Owner",
             "Content SHA",
             "MIME Type",
-            "Media Type",
-            "MIME Subtype",
             "ESIP-6",
             "L1 Block Number",
             "L2 Block Number",

--- a/contracts/test/EthscriptionsProver.t.sol
+++ b/contracts/test/EthscriptionsProver.t.sol
@@ -107,8 +107,6 @@ contract EthscriptionsProverTest is TestSetup {
                 initialOwner: alice,
                 content: bytes("test1"),
                 mimetype: "text/plain",
-                mediaType: "text",
-                mimeSubtype: "plain",
                 esip6: false,
                 protocolParams: Ethscriptions.ProtocolParams("", "", "")
             })
@@ -123,8 +121,6 @@ contract EthscriptionsProverTest is TestSetup {
                 initialOwner: bob,
                 content: bytes("test2"),
                 mimetype: "text/plain",
-                mediaType: "text",
-                mimeSubtype: "plain",
                 esip6: false,
                 protocolParams: Ethscriptions.ProtocolParams("", "", "")
             })
@@ -145,8 +141,6 @@ contract EthscriptionsProverTest is TestSetup {
                 initialOwner: charlie,
                 content: bytes("test3"),
                 mimetype: "text/plain",
-                mediaType: "text",
-                mimeSubtype: "plain",
                 esip6: false,
                 protocolParams: Ethscriptions.ProtocolParams("", "", "")
             })

--- a/contracts/test/EthscriptionsToken.t.sol
+++ b/contracts/test/EthscriptionsToken.t.sol
@@ -51,8 +51,6 @@ contract EthscriptionsTokenTest is TestSetup {
             initialOwner: initialOwner,
             content: content,
             mimetype: "text/plain",
-            mediaType: "text",
-            mimeSubtype: "plain",
             esip6: false,
             protocolParams: Ethscriptions.ProtocolParams({
                 protocolName: protocol,

--- a/contracts/test/EthscriptionsTokenParams.t.sol
+++ b/contracts/test/EthscriptionsTokenParams.t.sol
@@ -24,8 +24,6 @@ contract EthscriptionsTokenParamsTest is TestSetup {
             initialOwner: address(this),
             content: bytes(tokenJson),
             mimetype: "text/plain",
-            mediaType: "text",
-            mimeSubtype: "plain",
             esip6: false,
             protocolParams: Ethscriptions.ProtocolParams({
                 protocolName: "erc-20",
@@ -64,8 +62,6 @@ contract EthscriptionsTokenParamsTest is TestSetup {
             initialOwner: address(this),
             content: bytes(tokenJson),
             mimetype: "text/plain",
-            mediaType: "text",
-            mimeSubtype: "plain",
             esip6: false,
             protocolParams: Ethscriptions.ProtocolParams({
                 protocolName: "erc-20",
@@ -93,8 +89,6 @@ contract EthscriptionsTokenParamsTest is TestSetup {
             initialOwner: address(this),
             content: bytes(content),
             mimetype: "text/plain",
-            mediaType: "text",
-            mimeSubtype: "plain",
             esip6: false,
             protocolParams: Ethscriptions.ProtocolParams({
                 protocolName: "",
@@ -128,8 +122,6 @@ contract EthscriptionsTokenParamsTest is TestSetup {
             initialOwner: address(this),
             content: bytes(deployJson),
             mimetype: "application/json",
-            mediaType: "application",
-            mimeSubtype: "json",
             esip6: false,
             protocolParams: Ethscriptions.ProtocolParams({
                 protocolName: "erc-20",
@@ -156,8 +148,6 @@ contract EthscriptionsTokenParamsTest is TestSetup {
             initialOwner: address(this),
             content: bytes(mintJson),
             mimetype: "application/json",
-            mediaType: "application",
-            mimeSubtype: "json",
             esip6: false,
             protocolParams: Ethscriptions.ProtocolParams({
                 protocolName: "erc-20",

--- a/contracts/test/EthscriptionsWithContent.t.sol
+++ b/contracts/test/EthscriptionsWithContent.t.sol
@@ -20,8 +20,6 @@ contract EthscriptionsWithContentTest is TestSetup {
             initialOwner: initialOwner,
             content: bytes(testContent),
             mimetype: "text/plain",
-            mediaType: "text",
-            mimeSubtype: "plain",
             esip6: false,
             protocolParams: Ethscriptions.ProtocolParams({
                 protocolName: "",
@@ -40,10 +38,8 @@ contract EthscriptionsWithContentTest is TestSetup {
         assertEq(ethscription.initialOwner, initialOwner);
         assertEq(ethscription.previousOwner, creator);
         assertEq(ethscription.ethscriptionNumber, tokenId);
-        assertEq(ethscription.content.mimetype, "text/plain");
-        assertEq(ethscription.content.mediaType, "text");
-        assertEq(ethscription.content.mimeSubtype, "plain");
-        assertEq(ethscription.content.esip6, false);
+        assertEq(ethscription.mimetype, "text/plain");
+        assertEq(ethscription.esip6, false);
 
         // Verify content
         assertEq(content, bytes(testContent));
@@ -62,13 +58,11 @@ contract EthscriptionsWithContentTest is TestSetup {
         assertEq(ethscription.l2BlockNumber, ethscriptionSeparate.l2BlockNumber);
         assertEq(ethscription.l1BlockHash, ethscriptionSeparate.l1BlockHash);
 
-        // Compare content info
-        assertEq(ethscription.content.contentUriHash, ethscriptionSeparate.content.contentUriHash);
-        assertEq(ethscription.content.contentSha, ethscriptionSeparate.content.contentSha);
-        assertEq(ethscription.content.mimetype, ethscriptionSeparate.content.mimetype);
-        assertEq(ethscription.content.mediaType, ethscriptionSeparate.content.mediaType);
-        assertEq(ethscription.content.mimeSubtype, ethscriptionSeparate.content.mimeSubtype);
-        assertEq(ethscription.content.esip6, ethscriptionSeparate.content.esip6);
+        // Compare content fields
+        assertEq(ethscription.contentUriHash, ethscriptionSeparate.contentUriHash);
+        assertEq(ethscription.contentSha, ethscriptionSeparate.contentSha);
+        assertEq(ethscription.mimetype, ethscriptionSeparate.mimetype);
+        assertEq(ethscription.esip6, ethscriptionSeparate.esip6);
 
         // Compare content
         assertEq(content, contentSeparate);
@@ -102,8 +96,6 @@ contract EthscriptionsWithContentTest is TestSetup {
             initialOwner: initialOwner,
             content: largeContent,
             mimetype: "application/octet-stream",
-            mediaType: "application",
-            mimeSubtype: "octet-stream",
             esip6: false,
             protocolParams: Ethscriptions.ProtocolParams({
                 protocolName: "",

--- a/contracts/test/EthscriptionsWithTestFunctions.sol
+++ b/contracts/test/EthscriptionsWithTestFunctions.sol
@@ -14,14 +14,14 @@ contract EthscriptionsWithTestFunctions is Ethscriptions {
     /// @dev Test-only function to inspect storage chunks
     function getContentPointerCount(bytes32 transactionHash) external view requireExists(transactionHash) returns (uint256) {
         Ethscription storage etsc = ethscriptions[transactionHash];
-        return contentPointersBySha[etsc.content.contentSha].length;
+        return contentPointersBySha[etsc.contentSha].length;
     }
 
     /// @notice Get all content pointers for an ethscription
     /// @dev Test-only function to inspect SSTORE2 addresses
     function getContentPointers(bytes32 transactionHash) external view requireExists(transactionHash) returns (address[] memory) {
         Ethscription storage etsc = ethscriptions[transactionHash];
-        return contentPointersBySha[etsc.content.contentSha];
+        return contentPointersBySha[etsc.contentSha];
     }
 
     /// @notice Read a specific chunk of content
@@ -31,7 +31,7 @@ contract EthscriptionsWithTestFunctions is Ethscriptions {
     /// @return The chunk data
     function readChunk(bytes32 transactionHash, uint256 index) external view requireExists(transactionHash) returns (bytes memory) {
         Ethscription storage etsc = ethscriptions[transactionHash];
-        address[] storage pointers = contentPointersBySha[etsc.content.contentSha];
+        address[] storage pointers = contentPointersBySha[etsc.contentSha];
         require(index < pointers.length, "Chunk index out of bounds");
         return SSTORE2.read(pointers[index]);
     }

--- a/contracts/test/GasDebug.t.sol
+++ b/contracts/test/GasDebug.t.sol
@@ -41,7 +41,7 @@ contract GasDebugTest is TestSetup {
             Ethscriptions.Ethscription memory etsc = ethscriptions.getEthscription(params.transactionHash);
             assertEq(etsc.creator, INITIAL_OWNER);
             assertEq(etsc.initialOwner, INITIAL_OWNER);
-            assertEq(etsc.content.mimetype, "image/png");
+            assertEq(etsc.mimetype, "image/png");
         } catch Error(string memory reason) {
             console.log("Failed with reason:", reason);
             revert(reason);

--- a/contracts/test/ProtocolRegistration.t.sol
+++ b/contracts/test/ProtocolRegistration.t.sol
@@ -117,8 +117,6 @@ contract ProtocolRegistrationTest is TestSetup {
             initialOwner: alice,
             content: bytes('{"p":"mock-protocol","op":"test"}'),
             mimetype: "application/json",
-            mediaType: "application",
-            mimeSubtype: "json",
             esip6: false,
             protocolParams: Ethscriptions.ProtocolParams({
                 protocolName: "mock-protocol",
@@ -163,8 +161,6 @@ contract ProtocolRegistrationTest is TestSetup {
             initialOwner: alice,
             content: bytes('{"p":"unregistered","op":"test"}'),
             mimetype: "application/json",
-            mediaType: "application",
-            mimeSubtype: "json",
             esip6: false,
             protocolParams: Ethscriptions.ProtocolParams({
                 protocolName: "unregistered",

--- a/contracts/test/TestImageSVGWrapper.t.sol
+++ b/contracts/test/TestImageSVGWrapper.t.sol
@@ -22,8 +22,6 @@ contract TestImageSVGWrapper is TestSetup {
             initialOwner: alice,
             content: pngContent,
             mimetype: "image/png",
-            mediaType: "image",
-            mimeSubtype: "png",
             esip6: false,
             protocolParams: Ethscriptions.ProtocolParams({
                 protocolName: "",

--- a/contracts/test/TestSetup.sol
+++ b/contracts/test/TestSetup.sol
@@ -69,8 +69,6 @@ abstract contract TestSetup is Test {
         // Simple parsing for tests
         bytes memory content;
         string memory mimetype = "text/plain";
-        string memory mediaType = "text";
-        string memory mimeSubtype = "plain";
         bool isBase64 = false;
 
         // Check if data URI and parse
@@ -125,22 +123,6 @@ abstract contract TestSetup is Test {
                         for (uint256 i = 0; i < mimeEnd - 5; i++) {
                             bytes(mimetype)[i] = contentUriBytes[5 + i];
                         }
-
-                        // Parse media type and subtype
-                        bytes memory mimetypeBytes = bytes(mimetype);
-                        for (uint256 i = 0; i < mimetypeBytes.length; i++) {
-                            if (mimetypeBytes[i] == '/') {
-                                mediaType = string(new bytes(i));
-                                for (uint256 j = 0; j < i; j++) {
-                                    bytes(mediaType)[j] = mimetypeBytes[j];
-                                }
-                                mimeSubtype = string(new bytes(mimetypeBytes.length - i - 1));
-                                for (uint256 j = 0; j < mimetypeBytes.length - i - 1; j++) {
-                                    bytes(mimeSubtype)[j] = mimetypeBytes[i + 1 + j];
-                                }
-                                break;
-                            }
-                        }
                     }
                 }
             }
@@ -154,8 +136,6 @@ abstract contract TestSetup is Test {
             initialOwner: initialOwner,
             content: content,
             mimetype: mimetype,
-            mediaType: mediaType,
-            mimeSubtype: mimeSubtype,
             esip6: esip6,
             protocolParams: Ethscriptions.ProtocolParams({
                 protocolName: "",

--- a/lib/block_validator.rb
+++ b/lib/block_validator.rb
@@ -465,19 +465,8 @@ class BlockValidator
       @errors << "Storage mimetype mismatch for #{tx_hash}: stored=#{stored[:mimetype]}, expected=#{creation[:mimetype]}"
     end
 
-    # Verify media_type - normalize to binary for comparison (with instrumentation)
-    media_type_match = binary_equal?(stored[:media_type], creation[:media_type])
-    record_comparison("storage_media_type_check", tx_hash, creation[:media_type], stored[:media_type], media_type_match, { l1_block: l1_block_num })
-    if !media_type_match
-      @errors << "Storage media_type mismatch for #{tx_hash}: stored=#{stored[:media_type]}, expected=#{creation[:media_type]}"
-    end
-
-    # Verify mime_subtype - normalize to binary for comparison (with instrumentation)
-    mime_subtype_match = binary_equal?(stored[:mime_subtype], creation[:mime_subtype])
-    record_comparison("storage_mime_subtype_check", tx_hash, creation[:mime_subtype], stored[:mime_subtype], mime_subtype_match, { l1_block: l1_block_num })
-    if !mime_subtype_match
-      @errors << "Storage mime_subtype mismatch for #{tx_hash}: stored=#{stored[:mime_subtype]}, expected=#{creation[:mime_subtype]}"
-    end
+    # Note: media_type and mime_subtype are no longer stored in the contract
+    # They are derived from mimetype in StorageReader for backward compatibility
 
     # Verify esip6 flag - must match exactly (with instrumentation)
     esip6_match = stored[:esip6] == creation[:esip6]

--- a/lib/storage_reader.rb
+++ b/lib/storage_reader.rb
@@ -105,17 +105,11 @@ class StorageReader
       ethscription_data = decoded[0]
       content_data = decoded[1]
 
-      # Derive media_type and mime_subtype from mimetype
-      mimetype = ethscription_data[6]  # mimetype is at index 6
-      media_type, mime_subtype = mimetype.split('/', 2) if mimetype
-
       {
         # Content fields
         content_uri_hash: '0x' + ethscription_data[0].unpack1('H*'),
         content_sha: '0x' + ethscription_data[1].unpack1('H*'),
-        mimetype: mimetype,
-        media_type: media_type,
-        mime_subtype: mime_subtype,
+        mimetype: ethscription_data[6],  # mimetype at index 6
         esip6: ethscription_data[9],  # bool at index 9
 
         # Main fields
@@ -161,17 +155,11 @@ class StorageReader
       # The struct is returned as an array
       ethscription_data = decoded[0]
 
-      # Derive media_type and mime_subtype from mimetype
-      mimetype = ethscription_data[6]  # mimetype is at index 6
-      media_type, mime_subtype = mimetype.split('/', 2) if mimetype
-
       {
         # Content fields
         content_uri_hash: '0x' + ethscription_data[0].unpack1('H*'),
         content_sha: '0x' + ethscription_data[1].unpack1('H*'),
-        mimetype: mimetype,
-        media_type: media_type,
-        mime_subtype: mime_subtype,
+        mimetype: ethscription_data[6],  # mimetype at index 6
         esip6: ethscription_data[9],  # bool at index 9
 
         # Main fields

--- a/spec/integration/ethscriptions_creation_spec.rb
+++ b/spec/integration/ethscriptions_creation_spec.rb
@@ -530,8 +530,6 @@ RSpec.describe "Ethscription Creation", type: :integration do
           # Verify content fields
           expect(stored[:content]).to eq("<svg>test</svg>")
           expect(stored[:mimetype]).to eq("image/svg+xml")
-          expect(stored[:media_type]).to eq("image")
-          expect(stored[:mime_subtype]).to eq("svg+xml")
 
           # Verify content URI hash
           expected_hash = Digest::SHA256.hexdigest(content_uri)
@@ -553,8 +551,6 @@ RSpec.describe "Ethscription Creation", type: :integration do
           stored = get_ethscription_content(results[:ethscription_ids].first)
 
           expect(stored[:mimetype]).to eq("application/json")
-          expect(stored[:media_type]).to eq("application")
-          expect(stored[:mime_subtype]).to eq("json")
 
           # Verify content URI hash matches
           expected_hash = Digest::SHA256.hexdigest(content_uri)


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Flattens on-chain Ethscription storage (removes nested ContentInfo and mediaType/mimeSubtype), updates ABI/calldata, renderer, prover, genesis script, Ruby readers/validator, and tests; also enforces a max mimetype length.
> 
> - **Contracts (Solidity)**:
>   - **Ethscriptions.sol**: Flatten `Ethscription` (promote `contentUriHash`, `contentSha`, `mimetype`, `esip6`; add `l1BlockHash`; pack `uint48` fields); remove `ContentInfo` and all `mediaType`/`mimeSubtype` usage; update getters, content lookups, event emission, and storage writes.
>   - **Renderer Lib**: Use `etsc.mimetype` and flattened hashes; drop media/subtype attributes; adjust attribute JSON and media URI logic.
>   - **Prover**: Compact proof structs to `uint48` fields; include `l1BlockHash`; read flattened fields.
>   - **Genesis script**: Write flattened fields in `createGenesisEthscription`; remove media/subtype params; parse JSON without them.
>   - **Scripts/Tests**: Remove `mediaType`/`mimeSubtype` from `CreateEthscriptionParams` usage and assertions; update expected attributes (fewer traits) and field accessors.
> - **Ruby Backend**:
>   - **ethscription_transaction.rb**: Update function signature and ABI encoding for `createEthscription` (no media/subtype); add `MAX_MIMETYPE_LENGTH` and truncate mimetype.
>   - **storage_reader.rb**: Switch ABI decoding to flattened struct/`uint48` fields and indexes; update `get_ethscription_with_content`/`get_ethscription` to return flattened fields; remove media/subtype outputs.
>   - **block_validator.rb**: Stop validating `media_type`/`mime_subtype`; note they’re derived; continue mimetype/esip6 checks.
> - **Events/Calldata**:
>   - Update function selector strings and ABI tuples to `(bytes32,bytes32,address,bytes,string,bool,(string,string,bytes))` for create; fix event emission to use flattened `contentUriHash/contentSha`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 33c88910a77f9066325455ecf34f0fa88f724bc9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->