### PR TITLE
Simplify tokens

### DIFF
--- a/contracts/test/EthscriptionsToken.t.sol
+++ b/contracts/test/EthscriptionsToken.t.sol
@@ -87,7 +87,6 @@ contract EthscriptionsTokenTest is TestSetup {
         // Verify token was deployed
         TokenManager.TokenInfo memory tokenInfo = tokenManager.getTokenInfo(DEPLOY_TX_HASH);
             
-        assertEq(tokenInfo.protocol, "erc-20");
         assertEq(tokenInfo.tick, "TEST");
         assertEq(tokenInfo.maxSupply, 1000000);
         assertEq(tokenInfo.mintAmount, 1000);

--- a/lib/token_reader.rb
+++ b/lib/token_reader.rb
@@ -47,24 +47,23 @@ class TokenReader
     # struct TokenInfo {
     #   address tokenContract;
     #   bytes32 deployTxHash;
-    #   string protocol;
     #   string tick;
     #   uint256 maxSupply;
     #   uint256 mintAmount;
     #   uint256 totalMinted;
     # }
-    output_types = ['(address,bytes32,string,string,uint256,uint256,uint256)']
+    output_types = ['(address,bytes32,string,uint256,uint256,uint256)']
     decoded = Eth::Abi.decode(output_types, [result.delete_prefix('0x')].pack('H*'))
     token_tuple = decoded[0]
 
     {
       tokenContract: token_tuple[0],
       deployTxHash: '0x' + token_tuple[1].unpack1('H*'),
-      protocol: token_tuple[2],
-      tick: token_tuple[3],
-      maxSupply: token_tuple[4],
-      mintLimit: token_tuple[5], # mintAmount field is used as mintLimit
-      totalMinted: token_tuple[6],
+      protocol: 'erc-20',  # Always erc-20 for TokenManager
+      tick: token_tuple[2],
+      maxSupply: token_tuple[3],
+      mintLimit: token_tuple[4], # mintAmount field is used as mintLimit
+      totalMinted: token_tuple[5],
       # For backwards compatibility, add deployer field (not available in TokenInfo)
       deployer: nil,
       ethscriptionId: '0x' + token_tuple[1].unpack1('H*') # deployTxHash is the ethscriptionId


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Removes `protocol` from `TokenInfo`, inlines deploy logic in `op_deploy`, and updates Ruby reader and tests to the new ABI/layout.
> 
> - **Contracts (`contracts/src/TokenManager.sol`)**:
>   - Remove `protocol` from `TokenInfo` and related storage/writes.
>   - Inline deploy validation and clone initialization directly in `op_deploy`; remove `_deployToken`.
>   - Store token info without `protocol`; map `deployToTick` and emit `TokenDeployed` as before.
>   - Note: ABI of `getTokenInfo*` tuple changed (protocol string removed; field order shifted).
> - **Tests (`contracts/test/EthscriptionsToken.t.sol`)**:
>   - Drop assertion on `tokenInfo.protocol` to match new struct.
> - **Backend (`lib/token_reader.rb`)**:
>   - Update ABI decoding for `TokenInfo` (remove protocol field, adjust indices).
>   - Set `protocol: 'erc-20'` client-side; keep `mintLimit` mapped from `mintAmount`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 887867fec3c8ad04e3163569040f99c3aa1f36f4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->