### PR TITLE
Big rename and reorg

### DIFF
--- a/app/models/ethscription_transaction.rb
+++ b/app/models/ethscription_transaction.rb
@@ -199,7 +199,7 @@ class EthscriptionTransaction < T::Struct
 
     # Encode parameters
     params = [
-      tx_hash_bin,                            # bytes32 transactionHash
+      tx_hash_bin,                            # bytes32 ethscriptionId (L1 tx hash)
       content_uri_hash,                        # bytes32 contentUriHash
       owner_bin,                               # address
       raw_content,                             # bytes content

--- a/contracts/script/TestTokenUri.s.sol
+++ b/contracts/script/TestTokenUri.s.sol
@@ -17,7 +17,7 @@ contract TestTokenUri is Script {
         // Test case 1: Plain text (should use viewer)
         vm.prank(address(0x1111));
         eth.createEthscription(Ethscriptions.CreateEthscriptionParams({
-            transactionHash: keccak256("text1"),
+            ethscriptionId: keccak256("text1"),
             contentUriHash: keccak256("data:text/plain,Hello World!"),
             initialOwner: address(0x1111),
             content: bytes("Hello World!"),
@@ -29,7 +29,7 @@ contract TestTokenUri is Script {
         // Test case 2: JSON content (should use viewer with pretty print)
         vm.prank(address(0x2222));
         eth.createEthscription(Ethscriptions.CreateEthscriptionParams({
-            transactionHash: keccak256("json1"),
+            ethscriptionId: keccak256("json1"),
             contentUriHash: keccak256('data:application/json,{"p":"erc-20","op":"mint","tick":"test","amt":"1000"}'),
             initialOwner: address(0x2222),
             content: bytes('{"p":"erc-20","op":"mint","tick":"test","amt":"1000"}'),
@@ -41,7 +41,7 @@ contract TestTokenUri is Script {
         // Test case 3: HTML content (should pass through directly)
         vm.prank(address(0x3333));
         eth.createEthscription(Ethscriptions.CreateEthscriptionParams({
-            transactionHash: keccak256("html1"),
+            ethscriptionId: keccak256("html1"),
             contentUriHash: keccak256('data:text/html,<html><body style="background:linear-gradient(45deg,#ff006e,#8338ec);color:white;font-family:monospace;display:flex;align-items:center;justify-content:center;height:100vh;margin:0"><h1>Ethscriptions Rule!</h1></body></html>'),
             initialOwner: address(0x3333),
             content: bytes('<html><body style="background:linear-gradient(45deg,#ff006e,#8338ec);color:white;font-family:monospace;display:flex;align-items:center;justify-content:center;height:100vh;margin:0"><h1>Ethscriptions Rule!</h1></body></html>'),
@@ -54,7 +54,7 @@ contract TestTokenUri is Script {
         bytes memory redPixelPng = Base64.decode("iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAAm0lEQVR42mNgGITgPxTTxvBleTo0swBsOK0s+N8aJkczC1AMR7KAKpb8v72xAY5hFsD4lFoCN+j56ZUoliBbSoklGIZjwxRbQAjT1YK7d+82kGUBeuQii5FrAYYrL81NwCpGFQtoEUT/6RoHWAyknQV0S6ZI5RE6Jt8CZIOOHTuGgR9Fq5FkCf19QM3wx5rZKHEtsRZQt5qkhgUAR6cGaUehOD4AAAAASUVORK5CYII=");
         vm.prank(address(0x4444));
         eth.createEthscription(Ethscriptions.CreateEthscriptionParams({
-            transactionHash: keccak256("image1"),
+            ethscriptionId: keccak256("image1"),
             contentUriHash: keccak256("data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAAm0lEQVR42mNgGITgPxTTxvBleTo0swBsOK0s+N8aJkczC1AMR7KAKpb8v72xAY5hFsD4lFoCN+j56ZUoliBbSoklGIZjwxRbQAjT1YK7d+82kGUBeuQii5FrAYYrL81NwCpGFQtoEUT/6RoHWAyknQV0S6ZI5RE6Jt8CZIOOHTuGgR9Fq5FkCf19QM3wx5rZKHEtsRZQt5qkhgUAR6cGaUehOD4AAAAASUVORK5CYII="),
             initialOwner: address(0x4444),
             content: redPixelPng,
@@ -66,7 +66,7 @@ contract TestTokenUri is Script {
         // Test case 5: CSS content (should use viewer)
         vm.prank(address(0x5555));
         eth.createEthscription(Ethscriptions.CreateEthscriptionParams({
-            transactionHash: keccak256("css1"),
+            ethscriptionId: keccak256("css1"),
             contentUriHash: keccak256("data:text/css,body { background: #000; color: #0f0; font-family: 'Courier New'; }"),
             initialOwner: address(0x5555),
             content: bytes("body { background: #000; color: #0f0; font-family: 'Courier New'; }"),

--- a/contracts/src/CollectionsManager.sol
+++ b/contracts/src/CollectionsManager.sol
@@ -36,7 +36,7 @@ contract CollectionsManager is IProtocolHandler {
     // Runtime state for a collection (separate from metadata)
     struct CollectionState {
         address collectionContract;
-        bytes32 createTxHash;
+        bytes32 createEthscriptionId;
         uint256 currentSize;
         bool locked;
     }
@@ -135,7 +135,7 @@ contract CollectionsManager is IProtocolHandler {
     event CollectionLocked(bytes32 indexed collectionId);
 
     // Mirror success signaling so indexers can detect success without relying on router
-    event ProtocolHandlerSuccess(bytes32 indexed transactionHash, string protocol);
+    event ProtocolHandlerSuccess(bytes32 indexed ethscriptionId, string protocol);
 
     modifier onlyEthscriptions() {
         require(msg.sender == ethscriptions, "Only Ethscriptions contract");
@@ -169,7 +169,7 @@ contract CollectionsManager is IProtocolHandler {
         // Store collection state
         collectionState[collectionId] = CollectionState({
             collectionContract: collectionContract,
-            createTxHash: txHash,
+            createEthscriptionId: txHash,
             currentSize: 0,
             locked: false
         });
@@ -408,7 +408,7 @@ contract CollectionsManager is IProtocolHandler {
     /// @notice Handle transfer notification from Ethscriptions contract
     /// @dev When an ethscription that's part of a collection is transferred, sync the ERC721
     function onTransfer(
-        bytes32 txHash,
+        bytes32 ethscriptionId,
         address from,
         address to
     ) external override onlyEthscriptions {

--- a/contracts/src/Ethscriptions.sol
+++ b/contracts/src/Ethscriptions.sol
@@ -368,8 +368,7 @@ contract Ethscriptions is ERC721EthscriptionsUpgradeable {
 
     /// @notice Get ethscription details (returns struct to avoid stack too deep)
     function getEthscription(bytes32 ethscriptionId) external view returns (Ethscription memory) {
-        Ethscription storage ethscription = _getEthscriptionOrRevert(ethscriptionId);
-        return ethscription;
+        return _getEthscriptionOrRevert(ethscriptionId);
     }
 
     /// @notice Get content for an ethscription

--- a/contracts/src/EthscriptionsERC20.sol
+++ b/contracts/src/EthscriptionsERC20.sol
@@ -20,8 +20,8 @@ contract EthscriptionsERC20 is ERC20NullOwnerCappedUpgradeable {
     //                      STATE VARIABLES
     // =============================================================
 
-    /// @notice The ethscription hash that deployed this token
-    bytes32 public deployTxHash;
+    /// @notice The ethscription ID that deployed this token
+    bytes32 public deployEthscriptionId;
 
     // =============================================================
     //                      CUSTOM ERRORS
@@ -48,16 +48,16 @@ contract EthscriptionsERC20 is ERC20NullOwnerCappedUpgradeable {
     /// @param name_ The token name
     /// @param symbol_ The token symbol
     /// @param cap_ The maximum supply cap (in 18 decimals)
-    /// @param deployTxHash_ The ethscription hash that deployed this token
+    /// @param deployEthscriptionId_ The ethscription ID that deployed this token
     function initialize(
         string memory name_,
         string memory symbol_,
         uint256 cap_,
-        bytes32 deployTxHash_
+        bytes32 deployEthscriptionId_
     ) external initializer {
         __ERC20_init(name_, symbol_);
         __ERC20Capped_init(cap_);
-        deployTxHash = deployTxHash_;
+        deployEthscriptionId = deployEthscriptionId_;
     }
 
     /// @notice Mint tokens (TokenManager only)

--- a/contracts/src/EthscriptionsProver.sol
+++ b/contracts/src/EthscriptionsProver.sol
@@ -27,7 +27,7 @@ contract EthscriptionsProver {
 
     /// @notice Struct for ethscription data proof
     struct EthscriptionDataProof {
-        bytes32 ethscriptionTxHash;
+        bytes32 ethscriptionId;
         bytes32 contentSha;
         bytes32 contentUriHash;
         bytes32 l1BlockHash;
@@ -78,7 +78,7 @@ contract EthscriptionsProver {
 
     /// @notice Emitted when an ethscription data proof is sent to L1
     event EthscriptionDataProofSent(
-        bytes32 indexed ethscriptionTxHash,
+        bytes32 indexed ethscriptionId,
         uint256 indexed l2BlockNumber,
         uint256 l2Timestamp
     );
@@ -89,16 +89,16 @@ contract EthscriptionsProver {
 
     /// @notice Queue an ethscription for proving
     /// @dev Only callable by the Ethscriptions contract
-    /// @param txHash The transaction hash of the ethscription
-    function queueEthscription(bytes32 txHash) external virtual {
+    /// @param ethscriptionId The ID of the ethscription (L1 tx hash)
+    function queueEthscription(bytes32 ethscriptionId) external virtual {
         if (msg.sender != address(ethscriptions)) revert OnlyEthscriptions();
 
         // Add to the set (deduplicates automatically)
-        if (queuedEthscriptions.add(txHash)) {
-            // Only store info if this is the first time we're queueing this txHash
+        if (queuedEthscriptions.add(ethscriptionId)) {
+            // Only store info if this is the first time we're queueing this ID
             // Capture the L1 block hash and number at the time of queuing
             L1Block l1Block = L1Block(L1_BLOCK);
-            queuedProofInfo[txHash] = QueuedProof({
+            queuedProofInfo[ethscriptionId] = QueuedProof({
                 l1BlockHash: l1Block.hash(),
                 l2BlockNumber: uint48(block.number),
                 l2BlockTimestamp: uint48(block.timestamp),
@@ -117,14 +117,14 @@ contract EthscriptionsProver {
         // Process and remove each ethscription from the set
         // We iterate backwards to avoid index shifting during removal
         for (uint256 i = count; i > 0; i--) {
-            bytes32 txHash = queuedEthscriptions.at(i - 1);
+            bytes32 ethscriptionId = queuedEthscriptions.at(i - 1);
 
             // Create and send proof for current state with stored block info
-            _createAndSendProof(txHash, queuedProofInfo[txHash]);
+            _createAndSendProof(ethscriptionId, queuedProofInfo[ethscriptionId]);
 
             // Clean up: remove from set and delete the proof info
-            queuedEthscriptions.remove(txHash);
-            delete queuedProofInfo[txHash];
+            queuedEthscriptions.remove(ethscriptionId);
+            delete queuedProofInfo[ethscriptionId];
         }
     }
 
@@ -133,24 +133,24 @@ contract EthscriptionsProver {
     // =============================================================
 
     /// @notice Internal function to create and send proof for an ethscription
-    /// @param ethscriptionTxHash The transaction hash of the ethscription
+    /// @param ethscriptionId The Ethscription ID (L1 tx hash)
     /// @param proofInfo The queued proof info containing block data
-    function _createAndSendProof(bytes32 ethscriptionTxHash, QueuedProof memory proofInfo) internal {
+    function _createAndSendProof(bytes32 ethscriptionId, QueuedProof memory proofInfo) internal {
         // Get ethscription data including previous owner
-        Ethscriptions.Ethscription memory etsc = ethscriptions.getEthscription(ethscriptionTxHash);
-        address currentOwner = ethscriptions.ownerOf(ethscriptionTxHash);
+        Ethscriptions.Ethscription memory ethscription = ethscriptions.getEthscription(ethscriptionId);
+        address currentOwner = ethscriptions.ownerOf(ethscriptionId);
 
         // Create proof struct with all ethscription data
         EthscriptionDataProof memory proof = EthscriptionDataProof({
-            ethscriptionTxHash: ethscriptionTxHash,
-            contentSha: etsc.contentSha,
-            contentUriHash: etsc.contentUriHash,
+            ethscriptionId: ethscriptionId,
+            contentSha: ethscription.contentSha,
+            contentUriHash: ethscription.contentUriHash,
             l1BlockHash: proofInfo.l1BlockHash,
-            creator: etsc.creator,
+            creator: ethscription.creator,
             currentOwner: currentOwner,
-            previousOwner: etsc.previousOwner,
-            esip6: etsc.esip6,
-            ethscriptionNumber: etsc.ethscriptionNumber,
+            previousOwner: ethscription.previousOwner,
+            esip6: ethscription.esip6,
+            ethscriptionNumber: ethscription.ethscriptionNumber,
             l1BlockNumber: proofInfo.l1BlockNumber,
             l2BlockNumber: proofInfo.l2BlockNumber,
             l2Timestamp: proofInfo.l2BlockTimestamp
@@ -160,6 +160,6 @@ contract EthscriptionsProver {
         bytes memory proofData = abi.encode(proof);
         L2_TO_L1_MESSAGE_PASSER.initiateWithdrawal(address(0), 0, proofData);
 
-        emit EthscriptionDataProofSent(ethscriptionTxHash, proofInfo.l2BlockNumber, proofInfo.l2BlockTimestamp);
+        emit EthscriptionDataProofSent(ethscriptionId, proofInfo.l2BlockNumber, proofInfo.l2BlockTimestamp);
     }
 }

--- a/contracts/src/interfaces/IProtocolHandler.sol
+++ b/contracts/src/interfaces/IProtocolHandler.sol
@@ -6,11 +6,11 @@ pragma solidity 0.8.24;
 /// @dev Handlers process protocol-specific logic for Ethscriptions lifecycle events
 interface IProtocolHandler {
     /// @notice Called when an Ethscription with this protocol is transferred
-    /// @param txHash The transaction hash (Ethscription ID)
+    /// @param ethscriptionId The Ethscription ID (L1 tx hash)
     /// @param from The address transferring the Ethscription
     /// @param to The address receiving the Ethscription
     function onTransfer(
-        bytes32 txHash,
+        bytes32 ethscriptionId,
         address from,
         address to
     ) external;

--- a/contracts/src/libraries/EthscriptionsRendererLib.sol
+++ b/contracts/src/libraries/EthscriptionsRendererLib.sol
@@ -13,17 +13,17 @@ library EthscriptionsRendererLib {
 
     /// @notice Build attributes JSON array from ethscription data
     /// @param etsc Storage pointer to the ethscription
-    /// @param txHash The transaction hash of the ethscription
+    /// @param ethscriptionId The ethscription ID (L1 tx hash)
     /// @return JSON string of attributes array
-    function buildAttributes(Ethscriptions.Ethscription storage etsc, bytes32 txHash)
+    function buildAttributes(Ethscriptions.Ethscription storage etsc, bytes32 ethscriptionId)
         internal
         view
         returns (string memory)
     {
         // Build in chunks to avoid stack too deep
         string memory part1 = string.concat(
-            '[{"trait_type":"Transaction Hash","value":"',
-            uint256(txHash).toHexString(),
+            '[{"trait_type":"Ethscription ID","value":"',
+            uint256(ethscriptionId).toHexString(),
             '"},{"trait_type":"Ethscription Number","display_type":"number","value":',
             etsc.ethscriptionNumber.toString(),
             '},{"trait_type":"Creator","value":"',
@@ -84,19 +84,19 @@ library EthscriptionsRendererLib {
 
     /// @notice Build complete token URI JSON
     /// @param etsc Storage pointer to the ethscription
-    /// @param txHash The transaction hash of the ethscription
+    /// @param ethscriptionId The ethscription ID (L1 tx hash)
     /// @param content The content bytes
     /// @return The complete base64-encoded data URI
     function buildTokenURI(
         Ethscriptions.Ethscription storage etsc,
-        bytes32 txHash,
+        bytes32 ethscriptionId,
         bytes memory content
     ) internal view returns (string memory) {
         // Get media URI
         (string memory mediaType, string memory mediaUri) = getMediaUri(etsc, content);
 
         // Build attributes
-        string memory attributes = buildAttributes(etsc, txHash);
+        string memory attributes = buildAttributes(etsc, ethscriptionId);
 
         // Build JSON
         string memory json = string.concat(

--- a/contracts/test/CollectionsManager.t.sol
+++ b/contracts/test/CollectionsManager.t.sol
@@ -41,7 +41,7 @@ contract CollectionsManagerTest is TestSetup {
         });
 
         Ethscriptions.CreateEthscriptionParams memory params = Ethscriptions.CreateEthscriptionParams({
-            transactionHash: COLLECTION_TX_HASH,
+            ethscriptionId: COLLECTION_TX_HASH,
             contentUriHash: sha256(bytes(collectionContent)),
             initialOwner: alice,
             content: bytes(collectionContent),
@@ -121,7 +121,7 @@ contract CollectionsManagerTest is TestSetup {
         });
 
         Ethscriptions.CreateEthscriptionParams memory itemParams = Ethscriptions.CreateEthscriptionParams({
-            transactionHash: ITEM1_TX_HASH,
+            ethscriptionId: ITEM1_TX_HASH,
             contentUriHash: sha256(bytes(itemContent)),
             initialOwner: alice,
             content: bytes(itemContent),
@@ -215,7 +215,7 @@ contract CollectionsManagerTest is TestSetup {
         });
 
         Ethscriptions.CreateEthscriptionParams memory removeParams = Ethscriptions.CreateEthscriptionParams({
-            transactionHash: bytes32(uint256(0xFEED)),
+            ethscriptionId: bytes32(uint256(0xFEED)),
             contentUriHash: sha256(bytes(removeContent)),
             initialOwner: alice,
             content: bytes(removeContent),
@@ -256,7 +256,7 @@ contract CollectionsManagerTest is TestSetup {
         });
 
         Ethscriptions.CreateEthscriptionParams memory removeParams = Ethscriptions.CreateEthscriptionParams({
-            transactionHash: bytes32(uint256(0xBAD)),
+            ethscriptionId: bytes32(uint256(0xBAD)),
             contentUriHash: sha256(bytes("data:,remove")),
             initialOwner: bob,
             content: bytes("remove"),
@@ -318,7 +318,7 @@ contract CollectionsManagerTest is TestSetup {
             });
 
             Ethscriptions.CreateEthscriptionParams memory itemParams = Ethscriptions.CreateEthscriptionParams({
-                transactionHash: itemHashes[i],
+                ethscriptionId: itemHashes[i],
                 contentUriHash: sha256(abi.encodePacked("item", i)),
                 initialOwner: owners[i],
                 content: abi.encodePacked("item", i),
@@ -393,7 +393,7 @@ contract CollectionsManagerTest is TestSetup {
 
         // Create the ethscription with image content
         Ethscriptions.CreateEthscriptionParams memory itemParams = Ethscriptions.CreateEthscriptionParams({
-            transactionHash: ITEM1_TX_HASH,
+            ethscriptionId: ITEM1_TX_HASH,
             contentUriHash: sha256(bytes(imageContent)),
             initialOwner: alice,
             content: bytes(imageContent),
@@ -462,7 +462,7 @@ contract CollectionsManagerTest is TestSetup {
         });
 
         Ethscriptions.CreateEthscriptionParams memory editParams = Ethscriptions.CreateEthscriptionParams({
-            transactionHash: bytes32(uint256(0xED171)),
+            ethscriptionId: bytes32(uint256(0xED171)),
             contentUriHash: sha256(bytes("edit")),
             initialOwner: alice,
             content: bytes("edit"),
@@ -499,7 +499,7 @@ contract CollectionsManagerTest is TestSetup {
         // First create the ethscription that we'll add to the collection
         vm.prank(alice);
         Ethscriptions.CreateEthscriptionParams memory itemCreationParams = Ethscriptions.CreateEthscriptionParams({
-            transactionHash: ITEM1_TX_HASH,
+            ethscriptionId: ITEM1_TX_HASH,
             contentUriHash: sha256(bytes("item content")),
             initialOwner: alice,
             content: bytes("item content"),
@@ -535,7 +535,7 @@ contract CollectionsManagerTest is TestSetup {
         });
 
         Ethscriptions.CreateEthscriptionParams memory addParams = Ethscriptions.CreateEthscriptionParams({
-            transactionHash: bytes32(uint256(0xADD1733)),
+            ethscriptionId: bytes32(uint256(0xADD1733)),
             contentUriHash: sha256(bytes("add")),
             initialOwner: alice,
             content: bytes("add"),
@@ -564,7 +564,7 @@ contract CollectionsManagerTest is TestSetup {
         });
 
         Ethscriptions.CreateEthscriptionParams memory editParams = Ethscriptions.CreateEthscriptionParams({
-            transactionHash: bytes32(uint256(0xED172)),
+            ethscriptionId: bytes32(uint256(0xED172)),
             contentUriHash: sha256(bytes("partial-edit")),
             initialOwner: alice,
             content: bytes("partial-edit"),
@@ -607,7 +607,7 @@ contract CollectionsManagerTest is TestSetup {
         });
 
         Ethscriptions.CreateEthscriptionParams memory editParams = Ethscriptions.CreateEthscriptionParams({
-            transactionHash: bytes32(uint256(0xBADED17)),
+            ethscriptionId: bytes32(uint256(0xBADED17)),
             contentUriHash: sha256(bytes("bad-edit")),
             initialOwner: bob,
             content: bytes("bad-edit"),
@@ -645,7 +645,7 @@ contract CollectionsManagerTest is TestSetup {
         });
 
         Ethscriptions.CreateEthscriptionParams memory editParams = Ethscriptions.CreateEthscriptionParams({
-            transactionHash: bytes32(uint256(0x901743)),
+            ethscriptionId: bytes32(uint256(0x901743)),
             contentUriHash: sha256(bytes("no-item")),
             initialOwner: alice,
             content: bytes("no-item"),
@@ -694,7 +694,7 @@ contract CollectionsManagerTest is TestSetup {
         ethscriptionIds[0] = ITEM1_TX_HASH;
 
         Ethscriptions.CreateEthscriptionParams memory syncParams = Ethscriptions.CreateEthscriptionParams({
-            transactionHash: bytes32(uint256(0x5914C)),
+            ethscriptionId: bytes32(uint256(0x5914C)),
             contentUriHash: sha256(bytes("sync")),
             initialOwner: charlie,
             content: bytes("sync"),
@@ -741,7 +741,7 @@ contract CollectionsManagerTest is TestSetup {
         ethscriptionIds[1] = ITEM2_TX_HASH;
 
         Ethscriptions.CreateEthscriptionParams memory syncParams = Ethscriptions.CreateEthscriptionParams({
-            transactionHash: bytes32(uint256(0x5914CD)),
+            ethscriptionId: bytes32(uint256(0x5914CD)),
             contentUriHash: sha256(bytes("sync-multi")),
             initialOwner: alice,
             content: bytes("sync-multi"),
@@ -771,7 +771,7 @@ contract CollectionsManagerTest is TestSetup {
         ethscriptionIds[0] = bytes32(uint256(0x999999)); // Non-existent in collection
 
         Ethscriptions.CreateEthscriptionParams memory syncParams = Ethscriptions.CreateEthscriptionParams({
-            transactionHash: bytes32(uint256(0x5914CE)),
+            ethscriptionId: bytes32(uint256(0x5914CE)),
             contentUriHash: sha256(bytes("sync-nonexistent")),
             initialOwner: alice,
             content: bytes("sync-nonexistent"),
@@ -797,7 +797,7 @@ contract CollectionsManagerTest is TestSetup {
         ethscriptionIds[0] = ITEM1_TX_HASH;
 
         Ethscriptions.CreateEthscriptionParams memory syncParams = Ethscriptions.CreateEthscriptionParams({
-            transactionHash: bytes32(uint256(0x5914CF)),
+            ethscriptionId: bytes32(uint256(0x5914CF)),
             contentUriHash: sha256(bytes("sync-fake")),
             initialOwner: alice,
             content: bytes("sync-fake"),
@@ -825,7 +825,7 @@ contract CollectionsManagerTest is TestSetup {
         vm.prank(alice);
 
         Ethscriptions.CreateEthscriptionParams memory lockParams = Ethscriptions.CreateEthscriptionParams({
-            transactionHash: bytes32(uint256(0x10CCC)),
+            ethscriptionId: bytes32(uint256(0x10CCC)),
             contentUriHash: sha256(bytes("lock")),
             initialOwner: alice,
             content: bytes("lock"),
@@ -854,7 +854,7 @@ contract CollectionsManagerTest is TestSetup {
         });
 
         Ethscriptions.CreateEthscriptionParams memory editParams = Ethscriptions.CreateEthscriptionParams({
-            transactionHash: bytes32(uint256(0x10C3ED)),
+            ethscriptionId: bytes32(uint256(0x10C3ED)),
             contentUriHash: sha256(bytes("locked-edit")),
             initialOwner: alice,
             content: bytes("locked-edit"),

--- a/contracts/test/CollectionsProtocol.t.sol
+++ b/contracts/test/CollectionsProtocol.t.sol
@@ -39,7 +39,7 @@ contract CollectionsProtocolTest is TestSetup {
         // Use the getter functions instead of direct mapping access
         CollectionsManager.CollectionState memory state = collectionsManager.getCollectionState(collectionId);
         assertNotEq(state.collectionContract, address(0), "Collection contract should be deployed");
-        assertEq(state.createTxHash, txHash, "Create tx hash should match");
+        assertEq(state.createEthscriptionId, txHash, "Create ethscription ID should match");
         assertEq(state.currentSize, 0, "Initial size should be 0");
         assertEq(state.locked, false, "Should not be locked");
 
@@ -77,7 +77,7 @@ contract CollectionsProtocolTest is TestSetup {
         bytes32 txHash = keccak256(abi.encodePacked("test_collection_tx", block.timestamp));
 
         Ethscriptions.CreateEthscriptionParams memory params = Ethscriptions.CreateEthscriptionParams({
-            transactionHash: txHash,
+            ethscriptionId: txHash,
             contentUriHash: keccak256(bytes(json)),
             initialOwner: alice,
             content: bytes(json),
@@ -105,7 +105,7 @@ contract CollectionsProtocolTest is TestSetup {
 
         // Verify the collection was created
         assertTrue(state.collectionContract != address(0), "Collection should exist");
-        assertEq(state.createTxHash, txHash);
+        assertEq(state.createEthscriptionId, txHash);
         assertEq(state.currentSize, 0);
         assertEq(state.locked, false);
 
@@ -159,7 +159,7 @@ contract CollectionsProtocolTest is TestSetup {
         CollectionsManager.CollectionState memory state = abi.decode(result, (CollectionsManager.CollectionState));
 
         assertTrue(state.collectionContract != address(0), "Should have collection contract");
-        assertEq(state.createTxHash, txHash);
+        assertEq(state.createEthscriptionId, txHash);
         assertEq(state.currentSize, 0);
         assertEq(state.locked, false);
 

--- a/contracts/test/ERC721Enumerable.t.sol
+++ b/contracts/test/ERC721Enumerable.t.sol
@@ -18,7 +18,7 @@ contract ERC721EnumerableTest is TestSetup {
         vm.prank(creator);
         return ethscriptions.createEthscription(
             Ethscriptions.CreateEthscriptionParams({
-                transactionHash: txHash,
+                ethscriptionId: txHash,
                 contentUriHash: keccak256(bytes(content)),
                 initialOwner: owner,
                 content: bytes(content),

--- a/contracts/test/EthscriptionsFailureHandling.t.sol
+++ b/contracts/test/EthscriptionsFailureHandling.t.sol
@@ -99,7 +99,7 @@ contract EthscriptionsFailureHandlingTest is TestSetup {
         string memory dataUri = "data:,Hello World with failing token manager";
 
         Ethscriptions.CreateEthscriptionParams memory params = Ethscriptions.CreateEthscriptionParams({
-            transactionHash: txHash,
+            ethscriptionId: txHash,
             contentUriHash: sha256(bytes(dataUri)),
             initialOwner: address(this),
             content: bytes("Hello World with failing token manager"),
@@ -181,7 +181,7 @@ contract EthscriptionsFailureHandlingTest is TestSetup {
         string memory dataUri = "data:,{\"p\":\"test\",\"op\":\"deploy\",\"tick\":\"FAIL\",\"max\":\"1000\",\"lim\":\"10\"}";
 
         Ethscriptions.CreateEthscriptionParams memory params = Ethscriptions.CreateEthscriptionParams({
-            transactionHash: txHash,
+            ethscriptionId: txHash,
             contentUriHash: sha256(bytes(dataUri)),
             initialOwner: address(this),
             content: bytes("{\"p\":\"test\",\"op\":\"deploy\",\"tick\":\"FAIL\",\"max\":\"1000\",\"lim\":\"10\"}"),

--- a/contracts/test/EthscriptionsMultiTransfer.t.sol
+++ b/contracts/test/EthscriptionsMultiTransfer.t.sol
@@ -227,7 +227,7 @@ contract EthscriptionsMultiTransferTest is TestSetup {
 
         // Check all expected attributes
         string[10] memory expectedTraits = [
-            "Transaction Hash",
+            "Ethscription ID",
             "Ethscription Number",
             "Creator",
             "Initial Owner",

--- a/contracts/test/EthscriptionsProver.t.sol
+++ b/contracts/test/EthscriptionsProver.t.sol
@@ -68,7 +68,7 @@ contract EthscriptionsProverTest is TestSetup {
             (EthscriptionsProver.EthscriptionDataProof)
         );
         
-        assertEq(decodedProof.ethscriptionTxHash, TEST_TX_HASH);
+        assertEq(decodedProof.ethscriptionId, TEST_TX_HASH);
         assertEq(decodedProof.creator, alice); // Creator should be alice due to vm.prank
         assertEq(decodedProof.currentOwner, bob);
         assertEq(decodedProof.previousOwner, alice);
@@ -102,7 +102,7 @@ contract EthscriptionsProverTest is TestSetup {
         vm.startPrank(alice);
         ethscriptions.createEthscription(
             Ethscriptions.CreateEthscriptionParams({
-                transactionHash: txHash1,
+                ethscriptionId: txHash1,
                 contentUriHash: keccak256("data:,test1"),
                 initialOwner: alice,
                 content: bytes("test1"),
@@ -116,7 +116,7 @@ contract EthscriptionsProverTest is TestSetup {
         vm.startPrank(bob);
         ethscriptions.createEthscription(
             Ethscriptions.CreateEthscriptionParams({
-                transactionHash: txHash2,
+                ethscriptionId: txHash2,
                 contentUriHash: keccak256("data:,test2"),
                 initialOwner: bob,
                 content: bytes("test2"),
@@ -136,7 +136,7 @@ contract EthscriptionsProverTest is TestSetup {
         vm.startPrank(charlie);
         ethscriptions.createEthscription(
             Ethscriptions.CreateEthscriptionParams({
-                transactionHash: txHash3,
+                ethscriptionId: txHash3,
                 contentUriHash: keccak256("data:,test3"),
                 initialOwner: charlie,
                 content: bytes("test3"),

--- a/contracts/test/EthscriptionsToken.t.sol
+++ b/contracts/test/EthscriptionsToken.t.sol
@@ -46,7 +46,7 @@ contract EthscriptionsTokenTest is TestSetup {
         }
 
         return Ethscriptions.CreateEthscriptionParams({
-            transactionHash: transactionHash,
+            ethscriptionId: transactionHash,
             contentUriHash: contentUriHash,
             initialOwner: initialOwner,
             content: content,

--- a/contracts/test/EthscriptionsTokenParams.t.sol
+++ b/contracts/test/EthscriptionsTokenParams.t.sol
@@ -19,7 +19,7 @@ contract EthscriptionsTokenParamsTest is TestSetup {
         });
 
         Ethscriptions.CreateEthscriptionParams memory params = Ethscriptions.CreateEthscriptionParams({
-            transactionHash: bytes32(uint256(1)),
+            ethscriptionId: bytes32(uint256(1)),
             contentUriHash: contentUriHash,
             initialOwner: address(this),
             content: bytes(tokenJson),
@@ -39,7 +39,7 @@ contract EthscriptionsTokenParamsTest is TestSetup {
         assertEq(ethscriptions.totalSupply(), 12, "Should have created new ethscription");
 
         // Get the ethscription data
-        Ethscriptions.Ethscription memory eth = ethscriptions.getEthscription(params.transactionHash);
+        Ethscriptions.Ethscription memory eth = ethscriptions.getEthscription(params.ethscriptionId);
         assertEq(eth.creator, address(this), "Creator should match");
         assertEq(eth.initialOwner, address(this), "Initial owner should match");
     }
@@ -57,7 +57,7 @@ contract EthscriptionsTokenParamsTest is TestSetup {
         });
 
         Ethscriptions.CreateEthscriptionParams memory params = Ethscriptions.CreateEthscriptionParams({
-            transactionHash: bytes32(uint256(2)),
+            ethscriptionId: bytes32(uint256(2)),
             contentUriHash: contentUriHash,
             initialOwner: address(this),
             content: bytes(tokenJson),
@@ -84,7 +84,7 @@ contract EthscriptionsTokenParamsTest is TestSetup {
         bytes32 contentUriHash = sha256(bytes(dataUri));
 
         Ethscriptions.CreateEthscriptionParams memory params = Ethscriptions.CreateEthscriptionParams({
-            transactionHash: bytes32(uint256(3)),
+            ethscriptionId: bytes32(uint256(3)),
             contentUriHash: contentUriHash,
             initialOwner: address(this),
             content: bytes(content),
@@ -117,7 +117,7 @@ contract EthscriptionsTokenParamsTest is TestSetup {
         });
 
         Ethscriptions.CreateEthscriptionParams memory deployParams = Ethscriptions.CreateEthscriptionParams({
-            transactionHash: keccak256("deploy_tx"),
+            ethscriptionId: keccak256("deploy_tx"),
             contentUriHash: sha256(bytes(deployUri)),
             initialOwner: address(this),
             content: bytes(deployJson),
@@ -143,7 +143,7 @@ contract EthscriptionsTokenParamsTest is TestSetup {
         });
 
         Ethscriptions.CreateEthscriptionParams memory mintParams = Ethscriptions.CreateEthscriptionParams({
-            transactionHash: keccak256("mint_tx"),
+            ethscriptionId: keccak256("mint_tx"),
             contentUriHash: sha256(bytes(mintUri)),
             initialOwner: address(this),
             content: bytes(mintJson),

--- a/contracts/test/EthscriptionsWithContent.t.sol
+++ b/contracts/test/EthscriptionsWithContent.t.sol
@@ -15,7 +15,7 @@ contract EthscriptionsWithContentTest is TestSetup {
         // Create the ethscription
         vm.prank(creator);
         Ethscriptions.CreateEthscriptionParams memory params = Ethscriptions.CreateEthscriptionParams({
-            transactionHash: txHash,
+            ethscriptionId: txHash,
             contentUriHash: keccak256(bytes("data:text/plain,Hello, World!")),
             initialOwner: initialOwner,
             content: bytes(testContent),
@@ -91,7 +91,7 @@ contract EthscriptionsWithContentTest is TestSetup {
         // Create the ethscription
         vm.prank(creator);
         Ethscriptions.CreateEthscriptionParams memory params = Ethscriptions.CreateEthscriptionParams({
-            transactionHash: txHash,
+            ethscriptionId: txHash,
             contentUriHash: keccak256(bytes("data:application/octet-stream,<large content>")),
             initialOwner: initialOwner,
             content: largeContent,

--- a/contracts/test/EthscriptionsWithTestFunctions.sol
+++ b/contracts/test/EthscriptionsWithTestFunctions.sol
@@ -12,26 +12,26 @@ contract EthscriptionsWithTestFunctions is Ethscriptions {
 
     /// @notice Get the number of content pointers for an ethscription
     /// @dev Test-only function to inspect storage chunks
-    function getContentPointerCount(bytes32 transactionHash) external view requireExists(transactionHash) returns (uint256) {
-        Ethscription storage etsc = ethscriptions[transactionHash];
-        return contentPointersBySha[etsc.contentSha].length;
+    function getContentPointerCount(bytes32 ethscriptionId) external view returns (uint256) {
+        Ethscription storage ethscription = _getEthscriptionOrRevert(ethscriptionId);
+        return contentPointersBySha[ethscription.contentSha].length;
     }
 
     /// @notice Get all content pointers for an ethscription
     /// @dev Test-only function to inspect SSTORE2 addresses
-    function getContentPointers(bytes32 transactionHash) external view requireExists(transactionHash) returns (address[] memory) {
-        Ethscription storage etsc = ethscriptions[transactionHash];
-        return contentPointersBySha[etsc.contentSha];
+    function getContentPointers(bytes32 ethscriptionId) external view returns (address[] memory) {
+        Ethscription storage ethscription = _getEthscriptionOrRevert(ethscriptionId);
+        return contentPointersBySha[ethscription.contentSha];
     }
 
     /// @notice Read a specific chunk of content
     /// @dev Test-only function to read individual SSTORE2 chunks
-    /// @param transactionHash The ethscription transaction hash
+    /// @param ethscriptionId The ethscription ID (L1 tx hash)
     /// @param index The chunk index to read
     /// @return The chunk data
-    function readChunk(bytes32 transactionHash, uint256 index) external view requireExists(transactionHash) returns (bytes memory) {
-        Ethscription storage etsc = ethscriptions[transactionHash];
-        address[] storage pointers = contentPointersBySha[etsc.contentSha];
+    function readChunk(bytes32 ethscriptionId, uint256 index) external view returns (bytes memory) {
+        Ethscription storage ethscription = _getEthscriptionOrRevert(ethscriptionId);
+        address[] storage pointers = contentPointersBySha[ethscription.contentSha];
         require(index < pointers.length, "Chunk index out of bounds");
         return SSTORE2.read(pointers[index]);
     }

--- a/contracts/test/GasDebug.t.sol
+++ b/contracts/test/GasDebug.t.sol
@@ -38,7 +38,7 @@ contract GasDebugTest is TestSetup {
             console.log("Token ID created:", tokenId);
 
             // Verify it was created
-            Ethscriptions.Ethscription memory etsc = ethscriptions.getEthscription(params.transactionHash);
+            Ethscriptions.Ethscription memory etsc = ethscriptions.getEthscription(params.ethscriptionId);
             assertEq(etsc.creator, INITIAL_OWNER);
             assertEq(etsc.initialOwner, INITIAL_OWNER);
             assertEq(etsc.mimetype, "image/png");

--- a/contracts/test/ProtocolRegistration.t.sol
+++ b/contracts/test/ProtocolRegistration.t.sol
@@ -112,7 +112,7 @@ contract ProtocolRegistrationTest is TestSetup {
         bytes32 txHash = bytes32(uint256(0x1234));
 
         Ethscriptions.CreateEthscriptionParams memory params = Ethscriptions.CreateEthscriptionParams({
-            transactionHash: txHash,
+            ethscriptionId: txHash,
             contentUriHash: sha256(bytes('data:,{"p":"mock-protocol","op":"test"}')),
             initialOwner: alice,
             content: bytes('{"p":"mock-protocol","op":"test"}'),
@@ -156,7 +156,7 @@ contract ProtocolRegistrationTest is TestSetup {
 
         // Create ethscription with unregistered protocol
         Ethscriptions.CreateEthscriptionParams memory params = Ethscriptions.CreateEthscriptionParams({
-            transactionHash: txHash,
+            ethscriptionId: txHash,
             contentUriHash: sha256(bytes('data:,{"p":"unregistered","op":"test"}')),
             initialOwner: alice,
             content: bytes('{"p":"unregistered","op":"test"}'),

--- a/contracts/test/TestImageSVGWrapper.t.sol
+++ b/contracts/test/TestImageSVGWrapper.t.sol
@@ -17,7 +17,7 @@ contract TestImageSVGWrapper is TestSetup {
 
         vm.prank(alice);
         ethscriptions.createEthscription(Ethscriptions.CreateEthscriptionParams({
-            transactionHash: txHash,
+            ethscriptionId: txHash,
             contentUriHash: sha256(bytes(pngDataUri)),
             initialOwner: alice,
             content: pngContent,

--- a/contracts/test/TestSetup.sol
+++ b/contracts/test/TestSetup.sol
@@ -131,7 +131,7 @@ abstract contract TestSetup is Test {
         }
 
         return Ethscriptions.CreateEthscriptionParams({
-            transactionHash: transactionHash,
+            ethscriptionId: transactionHash,
             contentUriHash: contentUriHash,
             initialOwner: initialOwner,
             content: content,

--- a/lib/block_validator.rb
+++ b/lib/block_validator.rb
@@ -109,7 +109,7 @@ class BlockValidator
     genesis_file = Rails.root.join('contracts', 'script', 'genesisEthscriptions.json')
     genesis_data = JSON.parse(File.read(genesis_file))
 
-    # Extract all transaction hashes from the ethscriptions array
+    # Extract all ethscription IDs (L1 tx hashes) from the ethscriptions array
     genesis_data['ethscriptions'].map { |e| e['transaction_hash'] }
   end
 

--- a/lib/event_decoder.rb
+++ b/lib/event_decoder.rb
@@ -111,9 +111,9 @@ class EventDecoder
     def decode_protocol_transfer(log, metadata = {})
       return nil unless log['topics']&.size >= 4
 
-      # Event EthscriptionTransferred(bytes32 indexed transactionHash, address indexed from, address indexed to, uint256 ethscriptionNumber)
+      # Event EthscriptionTransferred(bytes32 indexed ethscriptionId, address indexed from, address indexed to, uint256 ethscriptionNumber)
       # First 3 parameters are indexed, last one is in data
-      tx_hash = log['topics'][1]&.downcase  # bytes32 transactionHash
+      tx_hash = log['topics'][1]&.downcase  # bytes32 ethscriptionId
       from = decode_address_from_topic(log['topics'][2])
       to = decode_address_from_topic(log['topics'][3])
 

--- a/lib/storage_reader.rb
+++ b/lib/storage_reader.rb
@@ -27,7 +27,7 @@ class StorageReader
       'type' => 'function',
       'stateMutability' => 'view',
       'inputs' => [
-        { 'name' => 'transactionHash', 'type' => 'bytes32' }
+        { 'name' => 'ethscriptionId', 'type' => 'bytes32' }
       ],
       'outputs' => [
         ETHSCRIPTION_STRUCT_ABI
@@ -38,7 +38,7 @@ class StorageReader
       'type' => 'function',
       'stateMutability' => 'view',
       'inputs' => [
-        { 'name' => 'transactionHash', 'type' => 'bytes32' }
+        { 'name' => 'ethscriptionId', 'type' => 'bytes32' }
       ],
       'outputs' => [
         { 'name' => '', 'type' => 'bytes' }
@@ -49,7 +49,7 @@ class StorageReader
       'type' => 'function',
       'stateMutability' => 'view',
       'inputs' => [
-        { 'name' => 'transactionHash', 'type' => 'bytes32' }
+        { 'name' => 'ethscriptionId', 'type' => 'bytes32' }
       ],
       'outputs' => [
         { 'name' => '', 'type' => 'address' }
@@ -69,7 +69,7 @@ class StorageReader
       'type' => 'function',
       'stateMutability' => 'view',
       'inputs' => [
-        { 'name' => 'txHash', 'type' => 'bytes32' }
+        { 'name' => 'ethscriptionId', 'type' => 'bytes32' }
       ],
       'outputs' => [
         { 'name' => 'ethscription', **ETHSCRIPTION_STRUCT_ABI },
@@ -203,29 +203,29 @@ class StorageReader
       nil
     end
 
-    def get_owner(token_id, block_tag: 'latest')
+    def get_owner(ethscription_id, block_tag: 'latest')
       # Build function signature
       function_sig = Eth::Util.keccak256('ownerOf(bytes32)')[0...4]
 
-      # Token ID is the transaction hash as uint256
-      token_id_bytes32 = format_bytes32(token_id)
+      # Parameter is the ethscription ID (bytes32)
+      ethscription_id_bytes32 = format_bytes32(ethscription_id)
 
       # Encode the parameter
-      calldata = function_sig + [token_id_bytes32].pack('H*')
+      calldata = function_sig + [ethscription_id_bytes32].pack('H*')
 
       # Make the eth_call
       result = eth_call('0x' + calldata.unpack1('H*'), block_tag)
       # Some nodes return 0x when the call yields no data
       return nil if result == '0x'
       # Nil indicates an RPC/network failure
-      raise StandardError, "RPC call failed for ownerOf #{token_id}" if result.nil?
+      raise StandardError, "RPC call failed for ownerOf #{ethscription_id}" if result.nil?
 
       # Decode the result - ownerOf returns a single address
       decoded = Eth::Abi.decode(['address'], result)
       Eth::Address.new(decoded[0]).to_s
     rescue EthRpcClient::ExecutionRevertedError => e
       # Contract reverted - token doesn't exist
-      Rails.logger.debug "Token #{token_id} doesn't exist (contract reverted): #{e.message}"
+      Rails.logger.debug "Ethscription #{ethscription_id} doesn't exist (contract reverted): #{e.message}"
       nil
     end
 

--- a/spec/support/ethscriptions_test_helper.rb
+++ b/spec/support/ethscriptions_test_helper.rb
@@ -585,16 +585,14 @@ module EthscriptionsTestHelper
     # Return all ethscription transactions (both successful and failed)
     imported_ethscriptions = ethscription_transactions
     ethscription_ids = imported_ethscriptions.flat_map do |tx|
-      case tx.ethscription_operation
-      when :create
+      op = tx.ethscription_operation.to_s
+      case op
+      when 'create'
         # For create operations, the ethscription ID is the transaction hash
         [tx.eth_transaction.tx_hash.to_hex]
-      when :transfer
-        if tx.transfer_ids.present?
-          tx.transfer_ids  # Multi-transfer
-        else
-          [tx.ethscription_id]  # Single transfer
-        end
+      when 'transfer', 'transfer_with_previous_owner'
+        # Always use array form for transfers
+        Array.wrap(tx.transfer_ids)
       else
         [tx.eth_transaction.tx_hash.to_hex]  # Fallback
       end


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> System-wide rename from transactionHash to ethscriptionId (L1 tx hash), updating events, mappings, interfaces, and tooling, plus new ID/tokenId accessors and helper APIs.
> 
> - **Solidity Contracts**:
>   - **Ethscriptions**:
>     - Replace `transactionHash` with `ethscriptionId` across storage (`ethscriptions` mapping), events (`EthscriptionCreated`, `EthscriptionTransferred`, protocol handler events), and APIs (`createEthscription`, transfers, `exists`, `ownerOf`, `getTokenId`).
>     - Swap `tokenIdToTransactionHash` for `tokenIdToEthscriptionId`.
>     - Add helpers: `_getEthscriptionOrRevert(...)`, `getEthscription(uint256)`, `getEthscriptionContent(uint256)`, `getEthscriptionWithContent(uint256)`, `getEthscriptionId(uint256)`.
>     - Update `tokenURI`/renderer calls to pass `ethscriptionId` and adjust attributes label to "Ethscription ID".
>   - **Genesis/Script**:
>     - `GenesisEthscriptions` and `L2Genesis.s.sol` updated to use `ethscriptionId`; pending events store IDs.
>     - `TestTokenUri.s.sol` calls updated to new param.
>   - **Protocols**:
>     - `IProtocolHandler.onTransfer(bytes32)` param renamed to `ethscriptionId`.
>     - `TokenManager`: rename fields/mappings/events to `deployEthscriptionId`; update ops (`op_deploy`, `op_mint`, `onTransfer`) and getters accordingly.
>     - `CollectionsManager`: `CollectionState.createTxHash` -> `createEthscriptionId`; event `ProtocolHandlerSuccess` topic uses `ethscriptionId`; `onTransfer` signature updated.
>   - **Prover**:
>     - `EthscriptionsProver` struct/event fields renamed to `ethscriptionId`; queue/flush paths use IDs.
>   - **Libraries**:
>     - `EthscriptionsRendererLib` now labels attribute as "Ethscription ID" and accepts `ethscriptionId` in builders.
> - **Ruby Tooling**:
>   - Update `StorageReader` ABI and calls to accept `ethscriptionId` for `getEthscription*` and `ownerOf`.
>   - `EventDecoder` comments/decoding align with `ethscriptionId` terminology.
>   - `BlockValidator`: clarify genesis IDs wording; minor logic unchanged.
>   - `EthscriptionTransaction`: comment clarifies first param is `ethscriptionId (L1 tx hash)`.
> - **Tests/Fixtures**:
>   - Update all tests and scripts to use `ethscriptionId` in `CreateEthscriptionParams` and adjusted expectations (events, getters, renderer attributes).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3260421d52711993a4de6c8b73e75a9ac1c0d020. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->