### PR TITLE
Use upgradeable proxies for tokens and collections

### DIFF
--- a/contracts/src/L2/ProxyAdmin.sol
+++ b/contracts/src/L2/ProxyAdmin.sol
@@ -27,21 +27,21 @@ contract ProxyAdmin is Ownable {
     /// @notice Returns the admin of the given proxy address.
     /// @param _proxy Address of the proxy to get the admin of.
     /// @return Address of the admin of the proxy.
-    function getProxyAdmin(address payable _proxy) external view returns (address) {
+    function getProxyAdmin(address _proxy) external view returns (address) {
         return IStaticERC1967Proxy(_proxy).admin();
     }
 
     /// @notice Updates the admin of the given proxy address.
     /// @param _proxy    Address of the proxy to update.
     /// @param _newAdmin Address of the new proxy admin.
-    function changeProxyAdmin(address payable _proxy, address _newAdmin) external onlyOwner {
+    function changeProxyAdmin(address _proxy, address _newAdmin) external onlyOwner {
         Proxy(_proxy).changeAdmin(_newAdmin);
     }
 
     /// @notice Changes a proxy's implementation contract.
     /// @param _proxy          Address of the proxy to upgrade.
     /// @param _implementation Address of the new implementation address.
-    function upgrade(address payable _proxy, address _implementation) public onlyOwner {
+    function upgrade(address _proxy, address _implementation) public onlyOwner {
         Proxy(_proxy).upgradeTo(_implementation);
     }
 
@@ -51,14 +51,10 @@ contract ProxyAdmin is Ownable {
     /// @param _implementation Address of the new implementation address.
     /// @param _data           Data to trigger the new implementation with.
     function upgradeAndCall(
-        address payable _proxy,
+        address _proxy,
         address _implementation,
         bytes memory _data
-    )
-        external
-        payable
-        onlyOwner
-    {
-        Proxy(_proxy).upgradeToAndCall{ value: msg.value }(_implementation, _data);
+    ) external onlyOwner {
+        Proxy(_proxy).upgradeToAndCall(_implementation, _data);
     }
 }

--- a/contracts/src/libraries/Proxy.sol
+++ b/contracts/src/libraries/Proxy.sol
@@ -63,7 +63,6 @@ contract Proxy {
         bytes calldata _data
     )
         public
-        payable
         virtual
         proxyCallIfNotAdmin
         returns (bytes memory)

--- a/contracts/test/AddressPrediction.t.sol
+++ b/contracts/test/AddressPrediction.t.sol
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+import "forge-std/Test.sol";
+import "../src/libraries/Predeploys.sol";
+import "../src/libraries/Proxy.sol";
+import "../src/FixedFungibleProtocolHandler.sol";
+import "../src/CollectionsProtocolHandler.sol";
+import "../src/Ethscriptions.sol";
+import "@openzeppelin/contracts/utils/Create2.sol";
+import "./TestSetup.sol";
+
+contract AddressPredictionTest is TestSetup {
+    // Test predictable address for FixedFungibleProtocolHandler token proxies
+    function testPredictFixedFungibleTokenAddress() public {
+        // Arrange
+        string memory tick = "eths";
+        bytes32 deployTxHash = keccak256("deploy-eths");
+
+        // Prepare deploy op data
+        FixedFungibleProtocolHandler.DeployOperation memory deployOp = FixedFungibleProtocolHandler.DeployOperation({
+            tick: tick,
+            maxSupply: 1_000_000,
+            mintAmount: 1_000
+        });
+        bytes memory data = abi.encode(deployOp);
+
+        // Prediction via contract helper
+        address predicted = fixedFungibleHandler.predictTokenAddressByTick(tick);
+
+        // Act: call deploy as Ethscriptions (authorized)
+        vm.prank(Predeploys.ETHSCRIPTIONS);
+        fixedFungibleHandler.op_deploy(deployTxHash, data);
+
+        // Assert actual matches predicted
+        address actual = fixedFungibleHandler.getTokenAddressByTick(tick);
+        assertEq(actual, predicted, "Predicted token address should match actual deployed proxy");
+    }
+
+    // Test predictable address for CollectionsProtocolHandler collection proxies
+    function testPredictCollectionsAddress() public {
+        // Arrange
+        bytes32 collectionId = keccak256("collection-1");
+
+        CollectionsProtocolHandler.CollectionMetadata memory metadata = CollectionsProtocolHandler.CollectionMetadata({
+            name: "My Collection",
+            symbol: "MYC",
+            totalSupply: 1000,
+            description: "A test collection",
+            logoImageUri: "data:,logo",
+            bannerImageUri: "data:,banner",
+            backgroundColor: "#000000",
+            websiteLink: "https://example.com",
+            twitterLink: "",
+            discordLink: ""
+        });
+
+        // Manually compute predicted proxy address
+        bytes memory creationCode = abi.encodePacked(type(Proxy).creationCode, abi.encode(address(collectionsHandler)));
+        address predicted = Create2.computeAddress(collectionId, keccak256(creationCode), address(collectionsHandler));
+
+        // Act: create collection as Ethscriptions (authorized)
+        vm.prank(Predeploys.ETHSCRIPTIONS);
+        collectionsHandler.op_create_collection(collectionId, abi.encode(metadata));
+
+        // Assert deployed matches predicted
+        (address actual,,,) = collectionsHandler.collectionState(collectionId);
+        assertEq(actual, predicted, "Predicted collection address should match actual deployed proxy");
+    }
+}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Replace clone-based deployments with upgradeable CREATE2 proxies for tokens and collections, update deterministic address prediction, and adjust Proxy/ProxyAdmin APIs with a new test.
> 
> - **Protocols**:
>   - **Collections** (`contracts/src/CollectionsProtocolHandler.sol`):
>     - Replace `Clones` with CREATE2-deployed `Proxy`; initialize via `upgradeToAndCall` and transfer admin to `Predeploys.PROXY_ADMIN`.
>     - Rename template constant to `collectionsImplementation`; events and state now reference proxy address.
>     - Update `predictCollectionAddress` to use `Create2.computeAddress` with `Proxy` creation code.
>   - **Fixed-Fungible** (`contracts/src/FixedFungibleProtocolHandler.sol`):
>     - Replace `Clones` with CREATE2-deployed `Proxy`; initialize via `upgradeToAndCall` and transfer admin to `Predeploys.PROXY_ADMIN`.
>     - Rename template constant to `fixedFungibleImplementation`; events/state now reference proxy address.
>     - Update `predictTokenAddressByTick` to use `Create2.computeAddress` with `Proxy` creation code.
> - **Infrastructure**:
>   - **ProxyAdmin** (`contracts/src/L2/ProxyAdmin.sol`): unify function params to `address` (non-payable) and remove value forwarding in `upgradeAndCall`.
>   - **Proxy library** (`contracts/src/libraries/Proxy.sol`): remove `payable` from `upgradeToAndCall` signature.
> - **Tests**:
>   - Add `contracts/test/AddressPrediction.t.sol` to assert predicted proxy addresses match deployed addresses for both handlers.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 79e6dc0d13ede8f98ffe755be16e67587325bb58. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->