### PR TITLE
More efficient enumerable

### DIFF
--- a/contracts/src/CollectionsERC721.sol
+++ b/contracts/src/CollectionsERC721.sol
@@ -2,18 +2,20 @@
 pragma solidity 0.8.24;
 
 // import "@openzeppelin/contracts-upgradeable/token/ERC721/ERC721Upgradeable.sol";
-import "./ERC721EthscriptionsUpgradeable.sol";
+import "./ERC721EthscriptionsEnumerableUpgradeable.sol";
 // import "@openzeppelin/contracts-upgradeable/token/ERC721/extensions/ERC721EnumerableUpgradeable.sol";
 // import "@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol";
 import "./Ethscriptions.sol";
 import {LibString} from "solady/utils/LibString.sol";
 import {Base64} from "solady/utils/Base64.sol";
 import "./CollectionsProtocolHandler.sol";
+import {IERC721} from "@openzeppelin/contracts/token/ERC721/IERC721.sol";
+import {IERC721Metadata} from "@openzeppelin/contracts/token/ERC721/extensions/IERC721Metadata.sol";
 
 /// @title CollectionsERC721
 /// @notice ERC-721 contract for an Ethscription collection
 /// @dev Maintains internal state but overrides ownerOf to delegate to Ethscriptions contract
-contract CollectionsERC721 is ERC721EthscriptionsUpgradeable {
+contract CollectionsERC721 is ERC721EthscriptionsEnumerableUpgradeable {
     using LibString for *;
 
     /// @notice The main Ethscriptions contract
@@ -118,7 +120,12 @@ contract CollectionsERC721 is ERC721EthscriptionsUpgradeable {
     }
 
     // Override ownerOf to delegate to Ethscriptions contract
-    function ownerOf(uint256 tokenId) public view override returns (address) {
+    function ownerOf(uint256 tokenId)
+        public
+        view
+        override(ERC721EthscriptionsUpgradeable, IERC721)
+        returns (address)
+    {
         // Check if token exists in collection
         if (!_tokenExists(tokenId)) {
             revert("Token does not exist");
@@ -137,7 +144,12 @@ contract CollectionsERC721 is ERC721EthscriptionsUpgradeable {
     }
 
     // Override tokenURI to generate full metadata JSON
-    function tokenURI(uint256 tokenId) public view override returns (string memory) {
+    function tokenURI(uint256 tokenId)
+        public
+        view
+        override(ERC721EthscriptionsUpgradeable)
+        returns (string memory)
+    {
         if (!_tokenExists(tokenId)) {
             revert("Token does not exist");
         }
@@ -221,20 +233,36 @@ contract CollectionsERC721 is ERC721EthscriptionsUpgradeable {
     }
 
     // Block external transfers - only internal _transfer is allowed for syncing
-    function transferFrom(address, address, uint256) public pure override {
+    function transferFrom(address, address, uint256)
+        public
+        pure
+        override(ERC721EthscriptionsUpgradeable, IERC721)
+    {
         revert TransferNotAllowed();
     }
 
-    function safeTransferFrom(address, address, uint256, bytes memory) public pure override {
+    function safeTransferFrom(address, address, uint256, bytes memory)
+        public
+        pure
+        override(ERC721EthscriptionsUpgradeable, IERC721)
+    {
         revert TransferNotAllowed();
     }
 
     // Block approvals - not needed for non-transferable tokens
-    function approve(address, uint256) public pure override {
+    function approve(address, uint256)
+        public
+        pure
+        override(ERC721EthscriptionsUpgradeable, IERC721)
+    {
         revert TransferNotAllowed();
     }
 
-    function setApprovalForAll(address, bool) public pure override {
+    function setApprovalForAll(address, bool)
+        public
+        pure
+        override(ERC721EthscriptionsUpgradeable, IERC721)
+    {
         revert TransferNotAllowed();
     }
 }

--- a/contracts/src/ERC721EthscriptionsEnumerableUpgradeable.sol
+++ b/contracts/src/ERC721EthscriptionsEnumerableUpgradeable.sol
@@ -1,0 +1,67 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.24;
+
+import "./ERC721EthscriptionsUpgradeable.sol";
+import {IERC721Enumerable} from "@openzeppelin/contracts/token/ERC721/extensions/IERC721Enumerable.sol";
+import {IERC165} from "@openzeppelin/contracts/utils/introspection/IERC165.sol";
+
+/**
+ * @dev Enumerable mixin for collections that require general token ID tracking and burns.
+ */
+abstract contract ERC721EthscriptionsEnumerableUpgradeable is ERC721EthscriptionsUpgradeable, IERC721Enumerable {
+    /// @inheritdoc ERC165Upgradeable
+    function supportsInterface(bytes4 interfaceId)
+        public
+        view
+        virtual
+        override(ERC721EthscriptionsUpgradeable, IERC165)
+        returns (bool)
+    {
+        return interfaceId == type(IERC721Enumerable).interfaceId || super.supportsInterface(interfaceId);
+    }
+
+    /// @inheritdoc IERC721Enumerable
+    function tokenOfOwnerByIndex(address owner, uint256 index)
+        public
+        view
+        virtual
+        override(IERC721Enumerable, ERC721EthscriptionsUpgradeable)
+        returns (uint256)
+    {
+        return super.tokenOfOwnerByIndex(owner, index);
+    }
+
+    /// @inheritdoc IERC721Enumerable
+    function totalSupply() public view virtual override returns (uint256) {
+        ERC721EnumerableStorage storage $ = _getERC721EnumerableStorage();
+        return $._allTokens.length;
+    }
+
+    /// @inheritdoc IERC721Enumerable
+    function tokenByIndex(uint256 index) public view virtual override returns (uint256) {
+        ERC721EnumerableStorage storage $ = _getERC721EnumerableStorage();
+        if (index >= $._allTokens.length) {
+            revert ERC721OutOfBoundsIndex(address(0), index);
+        }
+        return $._allTokens[index];
+    }
+
+    function _afterTokenMint(uint256 tokenId) internal virtual override {
+        ERC721EnumerableStorage storage $ = _getERC721EnumerableStorage();
+        $._allTokensIndex[tokenId] = $._allTokens.length;
+        $._allTokens.push(tokenId);
+    }
+
+    function _beforeTokenRemoval(uint256 tokenId, address) internal virtual override {
+        ERC721EnumerableStorage storage $ = _getERC721EnumerableStorage();
+        uint256 tokenIndex = $._allTokensIndex[tokenId];
+        uint256 lastTokenIndex = $._allTokens.length - 1;
+        uint256 lastTokenId = $._allTokens[lastTokenIndex];
+
+        $._allTokens[tokenIndex] = lastTokenId;
+        $._allTokensIndex[lastTokenId] = tokenIndex;
+
+        delete $._allTokensIndex[tokenId];
+        $._allTokens.pop();
+    }
+}

--- a/contracts/src/ERC721EthscriptionsSequentialEnumerableUpgradeable.sol
+++ b/contracts/src/ERC721EthscriptionsSequentialEnumerableUpgradeable.sol
@@ -20,14 +20,16 @@ abstract contract ERC721EthscriptionsSequentialEnumerableUpgradeable is ERC721Et
         uint256 _mintCount;
     }
 
+    // keccak256(abi.encode(uint256(keccak256("openzeppelin.storage.ERC721SequentialEnumerableStorageLocation")) - 1)) & ~bytes32(uint256(0xff))
+    bytes32 private constant ERC721SequentialEnumerableStorageLocation = 0x154e8d00bf5f00755eebdfa0d432d05cad242742a46a00bbdb15798f33342700;
+
     function _getERC721SequentialEnumerableStorage()
         private
         pure
         returns (ERC721SequentialEnumerableStorage storage $)
     {
-        bytes32 slot = keccak256(abi.encode("ethscriptions.storage.ERC721SequentialEnumerable"));
         assembly {
-            $.slot := slot
+            $.slot := ERC721SequentialEnumerableStorageLocation
         }
     }
 

--- a/contracts/src/ERC721EthscriptionsSequentialEnumerableUpgradeable.sol
+++ b/contracts/src/ERC721EthscriptionsSequentialEnumerableUpgradeable.sol
@@ -1,0 +1,86 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.24;
+
+import "./ERC721EthscriptionsUpgradeable.sol";
+import {IERC721Enumerable} from "@openzeppelin/contracts/token/ERC721/extensions/IERC721Enumerable.sol";
+import {IERC165} from "@openzeppelin/contracts/utils/introspection/IERC165.sol";
+
+/**
+ * @dev Enumerable mixin for Ethscriptions-style collections where token IDs are
+ * sequential, start at zero, and tokens are never burned.
+ */
+abstract contract ERC721EthscriptionsSequentialEnumerableUpgradeable is ERC721EthscriptionsUpgradeable, IERC721Enumerable {
+    /// @dev Raised when a mint attempts to skip or reuse a token ID.
+    error ERC721SequentialEnumerableInvalidTokenId(uint256 expected, uint256 actual);
+    /// @dev Raised if a contract attempts to remove a token from supply.
+    error ERC721SequentialEnumerableTokenRemoval(uint256 tokenId);
+
+    /// @custom:storage-location erc7201:ethscriptions.storage.ERC721SequentialEnumerable
+    struct ERC721SequentialEnumerableStorage {
+        uint256 _mintCount;
+    }
+
+    function _getERC721SequentialEnumerableStorage()
+        private
+        pure
+        returns (ERC721SequentialEnumerableStorage storage $)
+    {
+        bytes32 slot = keccak256(abi.encode("ethscriptions.storage.ERC721SequentialEnumerable"));
+        assembly {
+            $.slot := slot
+        }
+    }
+
+    /// @inheritdoc ERC165Upgradeable
+    function supportsInterface(bytes4 interfaceId)
+        public
+        view
+        virtual
+        override(ERC721EthscriptionsUpgradeable, IERC165)
+        returns (bool)
+    {
+        return interfaceId == type(IERC721Enumerable).interfaceId || super.supportsInterface(interfaceId);
+    }
+
+    /// @inheritdoc IERC721Enumerable
+    function tokenOfOwnerByIndex(address owner, uint256 index)
+        public
+        view
+        virtual
+        override(IERC721Enumerable, ERC721EthscriptionsUpgradeable)
+        returns (uint256)
+    {
+        return super.tokenOfOwnerByIndex(owner, index);
+    }
+
+    /// @inheritdoc IERC721Enumerable
+    function totalSupply() public view virtual override returns (uint256) {
+        ERC721SequentialEnumerableStorage storage $ = _getERC721SequentialEnumerableStorage();
+        return $._mintCount;
+    }
+
+    /// @inheritdoc IERC721Enumerable
+    function tokenByIndex(uint256 index) public view virtual override returns (uint256) {
+        if (index >= totalSupply()) {
+            revert ERC721OutOfBoundsIndex(address(0), index);
+        }
+        return index;
+    }
+
+    function _afterTokenMint(uint256 tokenId) internal virtual override {
+        ERC721SequentialEnumerableStorage storage $ = _getERC721SequentialEnumerableStorage();
+
+        uint256 expectedId = $._mintCount;
+        if (tokenId != expectedId) {
+            revert ERC721SequentialEnumerableInvalidTokenId(expectedId, tokenId);
+        }
+
+        unchecked {
+            $._mintCount = expectedId + 1;
+        }
+    }
+
+    function _beforeTokenRemoval(uint256 tokenId, address) internal virtual override {
+        revert ERC721SequentialEnumerableTokenRemoval(tokenId);
+    }
+}

--- a/contracts/src/ERC721EthscriptionsUpgradeable.sol
+++ b/contracts/src/ERC721EthscriptionsUpgradeable.sol
@@ -3,7 +3,6 @@ pragma solidity 0.8.24;
 
 import {IERC721} from "@openzeppelin/contracts/token/ERC721/IERC721.sol";
 import {IERC721Metadata} from "@openzeppelin/contracts/token/ERC721/extensions/IERC721Metadata.sol";
-import {IERC721Enumerable} from "@openzeppelin/contracts/token/ERC721/extensions/IERC721Enumerable.sol";
 import {ContextUpgradeable} from "@openzeppelin/contracts-upgradeable/utils/ContextUpgradeable.sol";
 import {IERC165} from "@openzeppelin/contracts/utils/introspection/IERC165.sol";
 import {ERC165Upgradeable} from "@openzeppelin/contracts-upgradeable/utils/introspection/ERC165Upgradeable.sol";
@@ -22,7 +21,7 @@ import {Initializable} from "@openzeppelin/contracts-upgradeable/proxy/utils/Ini
  * - No burn function (transfer to address(0) instead)
  * - Keeps only core transfer and ownership logic
  */
-abstract contract ERC721EthscriptionsUpgradeable is Initializable, ContextUpgradeable, ERC165Upgradeable, IERC721, IERC721Metadata, IERC721Enumerable, IERC721Errors {
+abstract contract ERC721EthscriptionsUpgradeable is Initializable, ContextUpgradeable, ERC165Upgradeable, IERC721, IERC721Metadata, IERC721Errors {
     // Errors for enumerable functionality
     error ERC721OutOfBoundsIndex(address owner, uint256 index);
     error ERC721EnumerableForbiddenBatchMint();
@@ -62,7 +61,7 @@ abstract contract ERC721EthscriptionsUpgradeable is Initializable, ContextUpgrad
     // keccak256(abi.encode(uint256(keccak256("openzeppelin.storage.ERC721Enumerable")) - 1)) & ~bytes32(uint256(0xff))
     bytes32 private constant ERC721EnumerableStorageLocation = 0x645e039705490088daad89bae25049a34f4a9072d398537b1ab2425f24cbed00;
 
-    function _getERC721EnumerableStorage() private pure returns (ERC721EnumerableStorage storage $) {
+    function _getERC721EnumerableStorage() internal pure returns (ERC721EnumerableStorage storage $) {
         assembly {
             $.slot := ERC721EnumerableStorageLocation
         }
@@ -88,7 +87,6 @@ abstract contract ERC721EthscriptionsUpgradeable is Initializable, ContextUpgrad
         return
             interfaceId == type(IERC721).interfaceId ||
             interfaceId == type(IERC721Metadata).interfaceId ||
-            interfaceId == type(IERC721Enumerable).interfaceId ||
             super.supportsInterface(interfaceId);
     }
 
@@ -132,28 +130,13 @@ abstract contract ERC721EthscriptionsUpgradeable is Initializable, ContextUpgrad
      */
     function tokenURI(uint256 tokenId) public view virtual returns (string memory);
 
-    /// @inheritdoc IERC721Enumerable
-    function totalSupply() public view virtual returns (uint256) {
-        ERC721EnumerableStorage storage $ = _getERC721EnumerableStorage();
-        return $._allTokens.length;
-    }
-
-    /// @inheritdoc IERC721Enumerable
+    /// @dev Return token owned by `owner` at `index`.
     function tokenOfOwnerByIndex(address owner, uint256 index) public view virtual returns (uint256) {
         ERC721EnumerableStorage storage $ = _getERC721EnumerableStorage();
         if (index >= balanceOf(owner)) {
             revert ERC721OutOfBoundsIndex(owner, index);
         }
         return $._ownedTokens[owner][index];
-    }
-
-    /// @inheritdoc IERC721Enumerable
-    function tokenByIndex(uint256 index) public view virtual returns (uint256) {
-        ERC721EnumerableStorage storage $ = _getERC721EnumerableStorage();
-        if (index >= totalSupply()) {
-            revert ERC721OutOfBoundsIndex(address(0), index);
-        }
-        return $._allTokens[index];
     }
 
     /**
@@ -256,8 +239,8 @@ abstract contract ERC721EthscriptionsUpgradeable is Initializable, ContextUpgrad
             // This is a mint
             $._existsFlag[tokenId] = true;
 
-            // Add to all tokens enumeration
-            _addTokenToAllTokensEnumeration(tokenId);
+            // Allow derived contracts to adjust enumeration state for newly minted token
+            _afterTokenMint(tokenId);
 
             // Add to owner enumeration (also increments balance)
             _addTokenToOwnerEnumeration(to, tokenId);
@@ -335,9 +318,10 @@ abstract contract ERC721EthscriptionsUpgradeable is Initializable, ContextUpgrad
         if (!exists && $._existsFlag[tokenId]) {
             address owner = $._owners[tokenId];
 
+            _beforeTokenRemoval(tokenId, owner);
+
             // Remove from enumerations (balance is decremented inside _removeTokenFromOwnerEnumeration)
             _removeTokenFromOwnerEnumeration(owner, tokenId);
-            _removeTokenFromAllTokensEnumeration(tokenId);
 
             // Clear owner storage for cleanliness
             delete $._owners[tokenId];
@@ -376,16 +360,6 @@ abstract contract ERC721EthscriptionsUpgradeable is Initializable, ContextUpgrad
         unchecked {
             $._balances[to] += 1;
         }
-    }
-
-    /**
-     * @dev Private function to add a token to this extension's token tracking data structures.
-     * @param tokenId uint256 ID of the token to be added to the tokens list
-     */
-    function _addTokenToAllTokensEnumeration(uint256 tokenId) private {
-        ERC721EnumerableStorage storage $ = _getERC721EnumerableStorage();
-        $._allTokensIndex[tokenId] = $._allTokens.length;
-        $._allTokens.push(tokenId);
     }
 
     /**
@@ -429,28 +403,12 @@ abstract contract ERC721EthscriptionsUpgradeable is Initializable, ContextUpgrad
     }
 
     /**
-     * @dev Private function to remove a token from this extension's token tracking data structures.
-     * This has O(1) time complexity, but alters the order of the _allTokens array.
-     * @param tokenId uint256 ID of the token to be removed from the tokens list
+     * @dev Hook for derived contracts to react to token minting.
      */
-    function _removeTokenFromAllTokensEnumeration(uint256 tokenId) private {
-        ERC721EnumerableStorage storage $ = _getERC721EnumerableStorage();
-        // To prevent a gap in the tokens array, we store the last token in the index of the token to delete, and
-        // then delete the last slot (swap and pop).
+    function _afterTokenMint(uint256) internal virtual {}
 
-        uint256 lastTokenIndex = $._allTokens.length - 1;
-        uint256 tokenIndex = $._allTokensIndex[tokenId];
-
-        // When the token to delete is the last token, the swap operation is unnecessary. However, since this occurs so
-        // rarely (when the last minted token is burnt) that we still do the swap here to avoid the gas cost of adding
-        // an 'if' statement (like in _removeTokenFromOwnerEnumeration)
-        uint256 lastTokenId = $._allTokens[lastTokenIndex];
-
-        $._allTokens[tokenIndex] = lastTokenId; // Move the last token to the slot of the to-delete token
-        $._allTokensIndex[lastTokenId] = tokenIndex; // Update the moved token's index
-
-        // This also deletes the contents at the last position of the array
-        delete $._allTokensIndex[tokenId];
-        $._allTokens.pop();
-    }
+    /**
+     * @dev Hook for derived contracts to react to token removal.
+     */
+    function _beforeTokenRemoval(uint256, address) internal virtual {}
 }

--- a/contracts/src/Ethscriptions.sol
+++ b/contracts/src/Ethscriptions.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.24;
 
-import "./ERC721EthscriptionsUpgradeable.sol";
+import "./ERC721EthscriptionsSequentialEnumerableUpgradeable.sol";
 import {LibString} from "solady/utils/LibString.sol";
 import "./libraries/SSTORE2ChunkedStorageLib.sol";
 import "./libraries/EthscriptionsRendererLib.sol";
@@ -14,7 +14,7 @@ import "./libraries/Constants.sol";
 /// @title Ethscriptions ERC-721 Contract
 /// @notice Mints Ethscriptions as ERC-721 tokens based on L1 transaction data
 /// @dev Uses ethscription number as token ID and name, while transaction hash remains the primary identifier for function calls
-contract Ethscriptions is ERC721EthscriptionsUpgradeable {
+contract Ethscriptions is ERC721EthscriptionsSequentialEnumerableUpgradeable {
     using LibString for *;
     using SSTORE2ChunkedStorageLib for address[];
     using EthscriptionsRendererLib for Ethscription;

--- a/contracts/test/ERC721EthscriptionsMixins.t.sol
+++ b/contracts/test/ERC721EthscriptionsMixins.t.sol
@@ -1,0 +1,144 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.24;
+
+import "forge-std/Test.sol";
+import "../src/ERC721EthscriptionsSequentialEnumerableUpgradeable.sol";
+import "../src/ERC721EthscriptionsEnumerableUpgradeable.sol";
+
+contract SequentialEnumerableHarness is ERC721EthscriptionsSequentialEnumerableUpgradeable {
+    function initialize() external initializer {
+        __ERC721_init("SequentialHarness", "SEQH");
+    }
+
+    function mint(address to, uint256 tokenId) external {
+        _mint(to, tokenId);
+    }
+
+    function burn(uint256 tokenId) external {
+        _setTokenExists(tokenId, false);
+    }
+
+    function tokenURI(uint256) public pure override returns (string memory) {
+        return "";
+    }
+}
+
+contract EnumerableHarness is ERC721EthscriptionsEnumerableUpgradeable {
+    function initialize() external initializer {
+        __ERC721_init("EnumerableHarness", "ENUMH");
+    }
+
+    function mint(address to, uint256 tokenId) external {
+        _mint(to, tokenId);
+    }
+
+    function burn(uint256 tokenId) external {
+        _setTokenExists(tokenId, false);
+    }
+
+    function forceTransfer(address to, uint256 tokenId) external {
+        _update(to, tokenId, address(0));
+    }
+
+    function tokenURI(uint256) public pure override returns (string memory) {
+        return "";
+    }
+}
+
+contract ERC721EthscriptionsMixinsTest is Test {
+    SequentialEnumerableHarness internal sequential;
+    EnumerableHarness internal enumerable;
+
+    address internal alice = address(0xA11CE);
+    address internal bob = address(0xB0B);
+
+    function setUp() public {
+        sequential = new SequentialEnumerableHarness();
+        sequential.initialize();
+
+        enumerable = new EnumerableHarness();
+        enumerable.initialize();
+    }
+
+    function testSequentialMintEnforcesOrdering() public {
+        sequential.mint(alice, 0);
+        sequential.mint(alice, 1);
+
+        assertEq(sequential.totalSupply(), 2);
+        assertEq(sequential.tokenByIndex(0), 0);
+        assertEq(sequential.tokenByIndex(1), 1);
+        assertEq(sequential.tokenOfOwnerByIndex(alice, 0), 0);
+        assertEq(sequential.tokenOfOwnerByIndex(alice, 1), 1);
+    }
+
+    function testSequentialMintRejectsSkippedIds() public {
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                ERC721EthscriptionsSequentialEnumerableUpgradeable
+                    .ERC721SequentialEnumerableInvalidTokenId
+                    .selector,
+                0,
+                1
+            )
+        );
+        sequential.mint(alice, 1);
+    }
+
+    function testSequentialBurnForbidden() public {
+        sequential.mint(alice, 0);
+
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                ERC721EthscriptionsSequentialEnumerableUpgradeable
+                    .ERC721SequentialEnumerableTokenRemoval
+                    .selector,
+                0
+            )
+        );
+        sequential.burn(0);
+    }
+
+    function testEnumerableTracksSparseIdsAcrossBurns() public {
+        enumerable.mint(alice, 10);
+        enumerable.mint(alice, 20);
+        enumerable.mint(alice, 30);
+
+        assertEq(enumerable.totalSupply(), 3);
+        assertEq(enumerable.tokenByIndex(0), 10);
+        assertEq(enumerable.tokenByIndex(1), 20);
+        assertEq(enumerable.tokenByIndex(2), 30);
+
+        enumerable.burn(20);
+        assertEq(enumerable.totalSupply(), 2);
+        assertEq(enumerable.tokenByIndex(0), 10);
+        assertEq(enumerable.tokenByIndex(1), 30);
+        vm.expectRevert(
+            abi.encodeWithSelector(
+                ERC721EthscriptionsUpgradeable.ERC721OutOfBoundsIndex.selector,
+                address(0),
+                2
+            )
+        );
+        enumerable.tokenByIndex(2);
+
+        enumerable.mint(alice, 40);
+        assertEq(enumerable.totalSupply(), 3);
+        assertEq(enumerable.tokenByIndex(2), 40);
+    }
+
+    function testEnumerableUpdatesOwnerEnumerationOnTransfer() public {
+        enumerable.mint(alice, 1);
+        enumerable.mint(alice, 2);
+
+        assertEq(enumerable.balanceOf(alice), 2);
+        assertEq(enumerable.tokenOfOwnerByIndex(alice, 0), 1);
+        assertEq(enumerable.tokenOfOwnerByIndex(alice, 1), 2);
+
+        enumerable.forceTransfer(bob, 1);
+
+        assertEq(enumerable.balanceOf(alice), 1);
+        assertEq(enumerable.balanceOf(bob), 1);
+        assertEq(enumerable.tokenOfOwnerByIndex(alice, 0), 2);
+        assertEq(enumerable.tokenOfOwnerByIndex(bob, 0), 1);
+    }
+}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Extract enumerable logic into mixins and switch Ethscriptions to sequential enumerable while Collections uses general enumerable; add tests for both paths.
> 
> - **Core ERC721 (ethscriptions)**:
>   - Split enumerable features out of `ERC721EthscriptionsUpgradeable` into hooks (`_afterTokenMint`, `_beforeTokenRemoval`) and per-owner tracking; removed global `_allTokens` management and `IERC721Enumerable` from base.
>   - Added `ERC721EthscriptionsEnumerableUpgradeable` (sparse IDs, supports burns) and `ERC721EthscriptionsSequentialEnumerableUpgradeable` (sequential IDs, no burns) implementing `IERC721Enumerable` via the new hooks.
> - **Contracts**:
>   - `Ethscriptions` now extends `ERC721EthscriptionsSequentialEnumerableUpgradeable` (sequential supply, indexable by position).
>   - `CollectionsERC721` now extends `ERC721EthscriptionsEnumerableUpgradeable`; updated overrides to conform with `IERC721`/metadata interfaces and enumeration mixin.
> - **Tests**:
>   - Added `ERC721EthscriptionsMixins.t.sol` with harnesses and tests covering sequential ID enforcement, burn forbiddance, sparse ID tracking across burns, and owner enumeration updates on transfer.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c0b8975d6cfb1770c9352578a735da25001b724c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->