### PR TITLE
Big rename

### DIFF
--- a/app/models/erc20_fixed_denomination_parser.rb
+++ b/app/models/erc20_fixed_denomination_parser.rb
@@ -1,15 +1,14 @@
-# Extracts fixed-fungible token parameters from content URIs using strict regex validation
-# Protocol uniqueness is based on exact text matching, so we validate the exact format
-class FixedFungibleTokenParamsExtractor
+# Extracts fixed-denomination ERC-20 parameters from strict JSON inscriptions.
+class Erc20FixedDenominationParser
   # Constants
   DEFAULT_PARAMS = [''.b, ''.b, ''.b, 0, 0, 0].freeze
   UINT256_MAX = 2**256 - 1
   
   # Exact regex patterns for valid formats
-  # Protocol must be "erc-20" or "fixed-fungible" (case-sensitive)
+  # Protocol must be "erc-20" (legacy inscription) or the canonical identifier
   # Tick must be lowercase letters/numbers, max 28 chars
   # Numbers must be positive decimals without leading zeros
-  PROTOCOL_PATTERN = '(?:erc-20|fixed-fungible)'
+  PROTOCOL_PATTERN = '(?:erc-20|erc-20-fixed-denomination)'
   DEPLOY_REGEX = /\Adata:,\{"p":"#{PROTOCOL_PATTERN}","op":"deploy","tick":"([a-z0-9]{1,28})","max":"(0|[1-9][0-9]*)","lim":"(0|[1-9][0-9]*)"\}\z/
   MINT_REGEX = /\Adata:,\{"p":"#{PROTOCOL_PATTERN}","op":"mint","tick":"([a-z0-9]{1,28})","id":"(0|[1-9][0-9]*)","amt":"(0|[1-9][0-9]*)"\}\z/
 
@@ -25,7 +24,7 @@ class FixedFungibleTokenParamsExtractor
       # Validate uint256 bounds
       return DEFAULT_PARAMS if max > UINT256_MAX || lim > UINT256_MAX
 
-      return ['deploy'.b, 'fixed-fungible'.b, tick.b, max, lim, 0]
+      return ['deploy'.b, 'erc-20-fixed-denomination'.b, tick.b, max, lim, 0]
     end
 
     # Try mint format
@@ -37,7 +36,7 @@ class FixedFungibleTokenParamsExtractor
       # Validate uint256 bounds
       return DEFAULT_PARAMS if id > UINT256_MAX || amt > UINT256_MAX
 
-      return ['mint'.b, 'fixed-fungible'.b, tick.b, id, 0, amt]
+      return ['mint'.b, 'erc-20-fixed-denomination'.b, tick.b, id, 0, amt]
     end
 
     # No match - return default

--- a/app/models/erc721_ethscriptions_collection_parser.rb
+++ b/app/models/erc721_ethscriptions_collection_parser.rb
@@ -361,7 +361,3 @@ class Erc721EthscriptionsCollectionParser
     [data['collection_id'], data['ethscription_ids']]
   end
 end
-
-# Legacy alias for previous class name
-CollectionsParamsExtractor = Erc721EthscriptionsCollectionParser
-ERC721EthscriptionsCollectionParamsExtractor = Erc721EthscriptionsCollectionParser

--- a/app/models/erc721_ethscriptions_collection_parser.rb
+++ b/app/models/erc721_ethscriptions_collection_parser.rb
@@ -1,5 +1,5 @@
-# Strict extractor for Collections protocol with canonical JSON validation
-class CollectionsParamsExtractor
+# Strict extractor for the ERC-721 Ethscriptions collection protocol with canonical JSON validation
+class Erc721EthscriptionsCollectionParser
   # Default return for invalid input
   DEFAULT_PARAMS = [''.b, ''.b, ''.b].freeze
 
@@ -114,7 +114,7 @@ class CollectionsParamsExtractor
       return DEFAULT_PARAMS unless data.is_a?(Hash)
 
       # Check protocol
-      return DEFAULT_PARAMS unless data['p'] == 'collections'
+      return DEFAULT_PARAMS unless data['p'] == 'erc-721-ethscriptions-collection'
 
       # Get operation
       operation = data['op']
@@ -131,7 +131,7 @@ class CollectionsParamsExtractor
       # Validate field types and encode
       encoded_data = encode_operation(operation, encoding_data, schema)
 
-      ['collections'.b, operation.b, encoded_data.b]
+      ['erc-721-ethscriptions-collection'.b, operation.b, encoded_data.b]
 
     rescue JSON::ParserError, ValidationError => e
       Rails.logger.debug "Collections extraction failed: #{e.message}" if defined?(Rails)
@@ -361,3 +361,7 @@ class CollectionsParamsExtractor
     [data['collection_id'], data['ethscription_ids']]
   end
 end
+
+# Legacy alias for previous class name
+CollectionsParamsExtractor = Erc721EthscriptionsCollectionParser
+ERC721EthscriptionsCollectionParamsExtractor = Erc721EthscriptionsCollectionParser

--- a/app/models/generic_protocol_extractor.rb
+++ b/app/models/generic_protocol_extractor.rb
@@ -572,9 +572,9 @@ class GenericProtocolExtractor
     [type_hint, [hex_part.downcase].pack('H*')]
   end
 
-  # Helper method for fixed-fungible protocol parsing (shared with protocol extractor)
+  # Helper method for fixed-denomination ERC-20 parsing (shared with protocol extractor)
   def self.extract_token_params(content_uri)
     # Use the strict regex-based extractor for token protocol
-    FixedFungibleTokenParamsExtractor.extract(content_uri)
+    Erc20FixedDenominationParser.extract(content_uri)
   end
 end

--- a/app/models/protocol_extractor.rb
+++ b/app/models/protocol_extractor.rb
@@ -1,8 +1,8 @@
 # Unified protocol extractor that delegates to appropriate extractors
 class ProtocolExtractor
   # Default return values to check if extraction succeeded
-  TOKEN_DEFAULT_PARAMS = FixedFungibleTokenParamsExtractor::DEFAULT_PARAMS
-  COLLECTIONS_DEFAULT_PARAMS = CollectionsParamsExtractor::DEFAULT_PARAMS
+  TOKEN_DEFAULT_PARAMS = Erc20FixedDenominationParser::DEFAULT_PARAMS
+  COLLECTIONS_DEFAULT_PARAMS = Erc721EthscriptionsCollectionParser::DEFAULT_PARAMS
   GENERIC_DEFAULT_PARAMS = GenericProtocolExtractor::DEFAULT_PARAMS
 
   def self.extract(content_uri)
@@ -45,15 +45,15 @@ class ProtocolExtractor
   private
 
   def self.try_token_extractor(content_uri)
-    # FixedFungibleTokenParamsExtractor uses strict regex and returns DEFAULT_PARAMS if no match
+    # Erc20FixedDenominationParser uses strict regex and returns DEFAULT_PARAMS if no match
     # This enforces non-ESIP6 and exact JSON formatting implicitly.
-    params = FixedFungibleTokenParamsExtractor.extract(content_uri)
+    params = Erc20FixedDenominationParser.extract(content_uri)
 
     # Check if extraction succeeded (returns non-default params)
     if params != TOKEN_DEFAULT_PARAMS
       {
-        type: :fixed_fungible,
-        protocol: 'fixed-fungible',
+        type: :erc20_fixed_denomination,
+        protocol: 'erc-20-fixed-denomination',
         operation: params[0], # 'deploy' or 'mint'
         params: params,
         encoded_params: encode_token_params(params)
@@ -64,13 +64,13 @@ class ProtocolExtractor
   end
 
   def self.try_collections_extractor(content_uri)
-    # CollectionsParamsExtractor returns [''.b, ''.b, ''.b] if no match
-    protocol, operation, encoded_data = CollectionsParamsExtractor.extract(content_uri)
+    # Erc721EthscriptionsCollectionParser returns [''.b, ''.b, ''.b] if no match
+    protocol, operation, encoded_data = Erc721EthscriptionsCollectionParser.extract(content_uri)
 
     # Check if extraction succeeded
     if protocol != ''.b && operation != ''.b
       {
-        type: :collections,
+        type: :erc721_ethscriptions_collection,
         protocol: protocol,
         operation: operation,
         params: nil, # Collections doesn't return decoded params
@@ -135,14 +135,14 @@ class ProtocolExtractor
     if result.nil?
       # No protocol detected - return empty protocol params
       [''.b, ''.b, ''.b]
-    elsif result[:type] == :fixed_fungible
-      # Fixed-fungible protocol - return in ABI-ready format
+    elsif result[:type] == :erc20_fixed_denomination
+      # Fixed denomination ERC-20 protocol - return in ABI-ready format
       protocol = result[:protocol].b
       operation = result[:operation]
       # For tokens, encode the params properly
       encoded_data = encode_token_data(result[:params])
       [protocol, operation, encoded_data]
-    elsif result[:type] == :collections
+    elsif result[:type] == :erc721_ethscriptions_collection
       # Collections protocol - already has encoded data
       [result[:protocol], result[:operation], result[:encoded_params]]
     else
@@ -158,7 +158,7 @@ class ProtocolExtractor
 
     # Encode based on operation type (operation is passed separately now)
     # Use tuple encoding for struct compatibility with contracts
-    # IMPORTANT: Field order must match FixedFungibleProtocolHandler's struct definitions!
+    # IMPORTANT: Field order must match ERC20FixedDenominationManager's struct definitions!
     if op == 'deploy'.b
       # DeployOperation struct: tick, maxSupply, mintAmount
       # Our params: tick, max (val1), lim (val2)

--- a/app/services/eth_block_importer.rb
+++ b/app/services/eth_block_importer.rb
@@ -383,14 +383,10 @@ class EthBlockImporter
       ValidationJob.perform_later(block_number, l2_block_hashes)
     end
 
-    # Removed noisy per-block timing logs
-
     ImportProfiler.stop("import_single_block")
 
     [imported_ethscriptions_blocks, [eth_block]]
   end
-  
-  # Legacy batch import method removed - use import_single_block instead
   
   def import_next_block
     block_number = next_block_to_import

--- a/contracts/script/L2Genesis.s.sol
+++ b/contracts/script/L2Genesis.s.sol
@@ -198,9 +198,9 @@ contract L2Genesis is Script {
 
             // Wire up implementations for the Ethscriptions predeploys that use proxies
             bool isProxiedContract = addr == Predeploys.ETHSCRIPTIONS ||
-                addr == Predeploys.FIXED_FUNGIBLE_HANDLER ||
+                addr == Predeploys.ERC20_FIXED_DENOMINATION_MANAGER ||
                 addr == Predeploys.ETHSCRIPTIONS_PROVER ||
-                addr == Predeploys.COLLECTIONS_PROTOCOL_HANDLER;
+                addr == Predeploys.ERC721_ETHSCRIPTIONS_COLLECTION_MANAGER;
             if (isProxiedContract) {
                 address impl = Predeploys.predeployToCodeNamespace(addr);
                 setImplementation(addr, impl);
@@ -208,12 +208,12 @@ contract L2Genesis is Script {
         }
 
         // Set implementation code for non-ETHSCRIPTIONS contracts now
-        _setImplementationCodeNamed(Predeploys.FIXED_FUNGIBLE_HANDLER, "FixedFungibleProtocolHandler");
-        _setImplementationCodeNamed(Predeploys.COLLECTIONS_PROTOCOL_HANDLER, "CollectionsProtocolHandler");
+        _setImplementationCodeNamed(Predeploys.ERC20_FIXED_DENOMINATION_MANAGER, "ERC20FixedDenominationManager");
+        _setImplementationCodeNamed(Predeploys.ERC721_ETHSCRIPTIONS_COLLECTION_MANAGER, "ERC721EthscriptionsCollectionManager");
         _setImplementationCodeNamed(Predeploys.ETHSCRIPTIONS_PROVER, "EthscriptionsProver");
         // Templates live directly at their implementation addresses (no proxy wrapping)
-        _setCodeAt(Predeploys.FIXED_FUNGIBLE_TEMPLATE_IMPLEMENTATION, "FixedFungibleERC20");
-        _setCodeAt(Predeploys.COLLECTIONS_TEMPLATE_IMPLEMENTATION, "CollectionsERC721");
+        _setCodeAt(Predeploys.ERC20_FIXED_DENOMINATION_IMPLEMENTATION, "ERC20FixedDenomination");
+        _setCodeAt(Predeploys.ERC721_ETHSCRIPTIONS_COLLECTION_IMPLEMENTATION, "ERC721EthscriptionsCollection");
 
         // Create genesis Ethscriptions (writes via proxy to proxy storage)
         createGenesisEthscriptions();
@@ -226,8 +226,8 @@ contract L2Genesis is Script {
     function registerProtocolHandlers() internal {
         Ethscriptions ethscriptions = Ethscriptions(Predeploys.ETHSCRIPTIONS);
 
-        ethscriptions.registerProtocol("fixed-fungible", Predeploys.FIXED_FUNGIBLE_HANDLER);
-        console.log("Registered fixed-fungible protocol handler:", Predeploys.FIXED_FUNGIBLE_HANDLER);
+        ethscriptions.registerProtocol("erc-20-fixed-denomination", Predeploys.ERC20_FIXED_DENOMINATION_MANAGER);
+        console.log("Registered erc-20-fixed-denomination protocol handler:", Predeploys.ERC20_FIXED_DENOMINATION_MANAGER);
 
         // Check environment variable for collections
         // Default to true so forge tests work (they don't go through genesis_generator.rb)
@@ -235,9 +235,9 @@ contract L2Genesis is Script {
         bool enableCollections = vm.envOr("ENABLE_COLLECTIONS", true);
 
         if (enableCollections) {
-            // Register the collections protocol handler for collections operations
-            ethscriptions.registerProtocol("collections", Predeploys.COLLECTIONS_PROTOCOL_HANDLER);
-            console.log("Registered collections protocol handler:", Predeploys.COLLECTIONS_PROTOCOL_HANDLER);
+            // Register the collections protocol handler for ERC-721 Ethscriptions collections
+            ethscriptions.registerProtocol("erc-721-ethscriptions-collection", Predeploys.ERC721_ETHSCRIPTIONS_COLLECTION_MANAGER);
+            console.log("Registered erc-721-ethscriptions-collection protocol handler:", Predeploys.ERC721_ETHSCRIPTIONS_COLLECTION_MANAGER);
         } else {
             console.log("Collections protocol not registered (ENABLE_COLLECTIONS=false)");
         }

--- a/contracts/src/ERC20FixedDenominationManager.sol
+++ b/contracts/src/ERC20FixedDenominationManager.sol
@@ -3,16 +3,16 @@ pragma solidity 0.8.24;
 
 import "@openzeppelin/contracts/utils/Create2.sol";
 import {LibString} from "solady/utils/LibString.sol";
-import "./FixedFungibleERC20.sol";
+import "./ERC20FixedDenomination.sol";
 import "./libraries/Proxy.sol";
 import "./Ethscriptions.sol";
 import "./libraries/Predeploys.sol";
 import "./interfaces/IProtocolHandler.sol";
 
-/// @title FixedFungibleProtocolHandler
-/// @notice Implements the fixed-fungible token protocol enforced via Ethscriptions transfers
-/// @dev Deploys and controls FixedFungible ERC-20 clones; callable only by the Ethscriptions contract
-contract FixedFungibleProtocolHandler is IProtocolHandler {
+/// @title ERC20FixedDenominationManager
+/// @notice Manages ERC-20 tokens that move in a fixed denomination per mint/transfer lot.
+/// @dev Deploys and controls ERC20FixedDenomination proxies; callable only by the Ethscriptions contract.
+contract ERC20FixedDenominationManager is IProtocolHandler {
     using LibString for string;
 
     // =============================================================
@@ -30,10 +30,9 @@ contract FixedFungibleProtocolHandler is IProtocolHandler {
 
     struct TokenItem {
         bytes32 deployEthscriptionId;  // Which token this ethscription belongs to
-        uint256 amount;                 // How many tokens this ethscription represents
+        uint256 amount;                // How many tokens this ethscription represents
     }
 
-    // Protocol operation structs for cleaner decoding
     struct DeployOperation {
         string tick;
         uint256 maxSupply;
@@ -51,23 +50,18 @@ contract FixedFungibleProtocolHandler is IProtocolHandler {
     // =============================================================
 
     /// @dev Implementation contract used for proxy deployments
-    address public constant fixedFungibleImplementation = Predeploys.FIXED_FUNGIBLE_TEMPLATE_IMPLEMENTATION;
+    address public constant tokenImplementation = Predeploys.ERC20_FIXED_DENOMINATION_IMPLEMENTATION;
     address public constant ethscriptions = Predeploys.ETHSCRIPTIONS;
-    string public constant CANONICAL_PROTOCOL = "fixed-fungible";
-    string public constant PRETTY_PROTOCOL = "Fixed-Fungible";
+
+    string public constant protocolName = "erc-20-fixed-denomination";
 
     // =============================================================
     //                      STATE VARIABLES
     // =============================================================
 
-    /// @dev Track deployed tokens by protocol+tick for find-or-create
-    mapping(bytes32 => TokenInfo) internal tokensByTick;  // keccak256(abi.encode(protocol, tick)) => TokenInfo
-
-    /// @dev Map deploy ethscription ID to tick key for lookups
-    mapping(bytes32 => bytes32) public deployToTick;    // deployEthscriptionId => tickKey
-
-    /// @dev Track which ethscription is a token item
-    mapping(bytes32 => TokenItem) internal tokenItems;    // ethscription tx hash => TokenItem
+    mapping(bytes32 => TokenInfo) internal tokensByTick;
+    mapping(bytes32 => bytes32) public deployToTick;
+    mapping(bytes32 => TokenItem) internal tokenItems;
 
     // =============================================================
     //                      CUSTOM ERRORS
@@ -86,7 +80,7 @@ contract FixedFungibleProtocolHandler is IProtocolHandler {
     //                          EVENTS
     // =============================================================
 
-    event FixedFungibleTokenDeployed(
+    event ERC20FixedDenominationTokenDeployed(
         bytes32 indexed deployEthscriptionId,
         address indexed tokenAddress,
         string tick,
@@ -94,14 +88,14 @@ contract FixedFungibleProtocolHandler is IProtocolHandler {
         uint256 mintAmount
     );
 
-    event FixedFungibleTokenMinted(
+    event ERC20FixedDenominationTokenMinted(
         bytes32 indexed deployEthscriptionId,
         address indexed to,
         uint256 amount,
         bytes32 ethscriptionId
     );
 
-    event FixedFungibleTokenTransferred(
+    event ERC20FixedDenominationTokenTransferred(
         bytes32 indexed deployEthscriptionId,
         address indexed from,
         address indexed to,
@@ -122,45 +116,36 @@ contract FixedFungibleProtocolHandler is IProtocolHandler {
     //                    EXTERNAL FUNCTIONS
     // =============================================================
 
-    /// @notice Handle deploy operation
-    /// @param ethscriptionId The ethscription ID
-    /// @param data The encoded DeployOperation data
+    /// @notice Handles a deploy inscription for a fixed-denomination ERC-20.
+    /// @param ethscriptionId The deploy inscription hash (also used as CREATE2 salt).
+    /// @param data ABI-encoded DeployOperation parameters (tick, maxSupply, mintAmount).
     function op_deploy(bytes32 ethscriptionId, bytes calldata data) external virtual onlyEthscriptions {
-        // Decode the operation data
         DeployOperation memory deployOp = abi.decode(data, (DeployOperation));
 
         bytes32 tickKey = _getTickKey(deployOp.tick);
         TokenInfo storage token = tokensByTick[tickKey];
 
-        // Revert if token already exists
         if (token.deployEthscriptionId != bytes32(0)) revert TokenAlreadyDeployed();
-
-        // Validate deployment parameters
         if (deployOp.maxSupply == 0) revert InvalidMaxSupply();
         if (deployOp.mintAmount == 0) revert InvalidMintAmount();
         if (deployOp.maxSupply % deployOp.mintAmount != 0) revert MaxSupplyNotDivisibleByMintAmount();
 
-        // Deploy a Proxy via CREATE2 with this handler as temporary admin for initialization
         Proxy tokenProxy = new Proxy{salt: tickKey}(address(this));
 
-        // Build name/symbol and initialization calldata
-        string memory name = string.concat(PRETTY_PROTOCOL, " ", deployOp.tick);
-        string memory symbol = LibString.upper(deployOp.tick);
-        // Initialize with max supply in 18 decimals
-        // User maxSupply "1000000" means 1000000 * 10^18 smallest units
+        string memory name = deployOp.tick;
+        string memory symbol = deployOp.tick.upper();
+
         bytes memory initCalldata = abi.encodeWithSelector(
-            FixedFungibleERC20.initialize.selector,
+            ERC20FixedDenomination.initialize.selector,
             name,
             symbol,
             deployOp.maxSupply * 10**18,
             ethscriptionId
         );
-        // Set implementation and run initialize as admin
-        tokenProxy.upgradeToAndCall(fixedFungibleImplementation, initCalldata);
-        // Hand off admin to global ProxyAdmin so upgrades require system governance
+
+        tokenProxy.upgradeToAndCall(tokenImplementation, initCalldata);
         tokenProxy.changeAdmin(Predeploys.PROXY_ADMIN);
 
-        // Store token info
         tokensByTick[tickKey] = TokenInfo({
             tokenContract: address(tokenProxy),
             deployEthscriptionId: ethscriptionId,
@@ -170,10 +155,9 @@ contract FixedFungibleProtocolHandler is IProtocolHandler {
             totalMinted: 0
         });
 
-        // Map deploy ID to tick key for lookups
         deployToTick[ethscriptionId] = tickKey;
 
-        emit FixedFungibleTokenDeployed(
+        emit ERC20FixedDenominationTokenDeployed(
             ethscriptionId,
             address(tokenProxy),
             deployOp.tick,
@@ -182,52 +166,40 @@ contract FixedFungibleProtocolHandler is IProtocolHandler {
         );
     }
 
-    /// @notice Handle mint operation
-    /// @param ethscriptionId The ethscription ID
-    /// @param data The encoded MintOperation data
+    /// @notice Processes a mint inscription and mints the fixed denomination to the inscription owner.
+    /// @param ethscriptionId The mint inscription hash.
+    /// @param data ABI-encoded MintOperation parameters (tick, id, amount).
     function op_mint(bytes32 ethscriptionId, bytes calldata data) external virtual onlyEthscriptions {
-        // Decode the operation data
         MintOperation memory mintOp = abi.decode(data, (MintOperation));
 
         bytes32 tickKey = _getTickKey(mintOp.tick);
         TokenInfo storage token = tokensByTick[tickKey];
 
-        // Token must exist to mint
         if (token.deployEthscriptionId == bytes32(0)) revert TokenNotDeployed();
-
-        // Validate mint amount matches token's configured limit
         if (mintOp.amount != token.mintAmount) revert MintAmountMismatch();
 
-        // Validate mint ID is within valid range (1 to maxId)
-        // maxId = maxSupply / mintAmount (both are in user units, not 18 decimals)
         uint256 maxId = token.maxSupply / token.mintAmount;
         if (mintOp.id < 1 || mintOp.id > maxId) revert InvalidMintId();
 
-        // Get the initial owner from the Ethscriptions contract
         Ethscriptions ethscriptionsContract = Ethscriptions(ethscriptions);
         Ethscriptions.Ethscription memory ethscription = ethscriptionsContract.getEthscription(ethscriptionId);
         address initialOwner = ethscription.initialOwner;
 
-        // Track this ethscription as a token item
         tokenItems[ethscriptionId] = TokenItem({
             deployEthscriptionId: token.deployEthscriptionId,
             amount: mintOp.amount
         });
 
-        // Mint tokens to the initial owner - convert to 18 decimals
-        FixedFungibleERC20(token.tokenContract).mint(initialOwner, mintOp.amount * 10**18);
-
-        // Update total minted after successful mint
+        ERC20FixedDenomination(token.tokenContract).mint(initialOwner, mintOp.amount * 10**18);
         token.totalMinted += mintOp.amount;
 
-        emit FixedFungibleTokenMinted(token.deployEthscriptionId, initialOwner, mintOp.amount, ethscriptionId);
+        emit ERC20FixedDenominationTokenMinted(token.deployEthscriptionId, initialOwner, mintOp.amount, ethscriptionId);
     }
 
-    /// @notice Handle transfer notification from Ethscriptions contract
-    /// @dev Implementation of IProtocolHandler interface
-    /// @param ethscriptionId The ethscription ID being transferred
-    /// @param from The address transferring from
-    /// @param to The address transferring to
+    /// @notice Mirrors ERC-20 balances when a mint inscription NFT transfers.
+    /// @param ethscriptionId The mint inscription hash being transferred.
+    /// @param from The previous owner of the inscription NFT.
+    /// @param to The new owner of the inscription NFT.
     function onTransfer(
         bytes32 ethscriptionId,
         address from,
@@ -235,110 +207,64 @@ contract FixedFungibleProtocolHandler is IProtocolHandler {
     ) external virtual override onlyEthscriptions {
         TokenItem memory item = tokenItems[ethscriptionId];
 
-        // Not a token item, nothing to do
         if (item.deployEthscriptionId == bytes32(0)) return;
 
         bytes32 tickKey = deployToTick[item.deployEthscriptionId];
         TokenInfo storage token = tokensByTick[tickKey];
 
-        // Force transfer tokens (shadow transfer) - convert to 18 decimals
-        FixedFungibleERC20(token.tokenContract).forceTransfer(from, to, item.amount * 10**18);
+        ERC20FixedDenomination(token.tokenContract).forceTransfer(from, to, item.amount * 10**18);
 
-        emit FixedFungibleTokenTransferred(item.deployEthscriptionId, from, to, item.amount, ethscriptionId);
+        emit ERC20FixedDenominationTokenTransferred(item.deployEthscriptionId, from, to, item.amount, ethscriptionId);
     }
 
     // =============================================================
     //                  EXTERNAL VIEW FUNCTIONS
     // =============================================================
 
-    /// @notice Get token contract address by deploy ethscription ID
-    /// @param deployEthscriptionId The deployment ethscription ID
-    /// @return The token contract address
     function getTokenAddress(bytes32 deployEthscriptionId) external view returns (address) {
         bytes32 tickKey = deployToTick[deployEthscriptionId];
         return tokensByTick[tickKey].tokenContract;
     }
 
-    /// @notice Get token contract address by tick
-    /// @param tick The token tick symbol
-    /// @return The token contract address
     function getTokenAddressByTick(string memory tick) external view returns (address) {
         bytes32 tickKey = _getTickKey(tick);
         return tokensByTick[tickKey].tokenContract;
     }
 
-    /// @notice Get complete token information by deploy ethscription ID
-    /// @param deployEthscriptionId The deployment ethscription ID
-    /// @return The TokenInfo struct
     function getTokenInfo(bytes32 deployEthscriptionId) external view returns (TokenInfo memory) {
         bytes32 tickKey = deployToTick[deployEthscriptionId];
         return tokensByTick[tickKey];
     }
 
-    /// @notice Get complete token information by tick
-    /// @param tick The token tick symbol
-    /// @return The TokenInfo struct
     function getTokenInfoByTick(string memory tick) external view returns (TokenInfo memory) {
         bytes32 tickKey = _getTickKey(tick);
         return tokensByTick[tickKey];
     }
 
-    /// @notice Predict token address for a tick (before deployment)
-    /// @param tick The token tick symbol
-    /// @return The predicted or actual token address
     function predictTokenAddressByTick(string memory tick) external view returns (address) {
         bytes32 tickKey = _getTickKey(tick);
 
-        // Check if already deployed
         if (tokensByTick[tickKey].tokenContract != address(0)) {
             return tokensByTick[tickKey].tokenContract;
         }
 
-        // Predict using CREATE2 for Proxy with constructor arg (admin = address(this))
         bytes memory creationCode = abi.encodePacked(type(Proxy).creationCode, abi.encode(address(this)));
         return Create2.computeAddress(tickKey, keccak256(creationCode), address(this));
     }
 
-    /// @notice Check if an ethscription is a token item
-    /// @param ethscriptionId The ethscription ID
-    /// @return True if the ethscription represents tokens
     function isTokenItem(bytes32 ethscriptionId) external view returns (bool) {
         return tokenItems[ethscriptionId].deployEthscriptionId != bytes32(0);
     }
 
-    /// @notice Get token amount for an ethscription
-    /// @param ethscriptionId The ethscription ID
-    /// @return The amount of tokens this ethscription represents
-    function getTokenAmount(bytes32 ethscriptionId) external view returns (uint256) {
-        return tokenItems[ethscriptionId].amount;
-    }
-
-    /// @notice Get complete token item information
-    /// @param ethscriptionId The ethscription ID
-    /// @return The TokenItem struct
     function getTokenItem(bytes32 ethscriptionId) external view returns (TokenItem memory) {
         return tokenItems[ethscriptionId];
-    }
-
-    // =============================================================
-    //                   PUBLIC VIEW FUNCTIONS
-    // =============================================================
-
-    /// @notice Returns human-readable protocol name
-    /// @return The protocol name
-    function protocolName() public pure override returns (string memory) {
-        return CANONICAL_PROTOCOL;
     }
 
     // =============================================================
     //                    PRIVATE FUNCTIONS
     // =============================================================
 
-    /// @notice Generate tick key for storage mapping
-    /// @param tick The token tick symbol
-    /// @return The tick key for storage lookups
     function _getTickKey(string memory tick) private pure returns (bytes32) {
-        // Use the protocol name from this handler
-        return keccak256(abi.encode(CANONICAL_PROTOCOL, tick));
+        return keccak256(abi.encode(protocolName, tick));
     }
 }

--- a/contracts/src/ERC721EthscriptionsCollection.sol
+++ b/contracts/src/ERC721EthscriptionsCollection.sol
@@ -8,14 +8,14 @@ import "./ERC721EthscriptionsEnumerableUpgradeable.sol";
 import "./Ethscriptions.sol";
 import {LibString} from "solady/utils/LibString.sol";
 import {Base64} from "solady/utils/Base64.sol";
-import "./CollectionsProtocolHandler.sol";
+import "./ERC721EthscriptionsCollectionManager.sol";
 import {IERC721} from "@openzeppelin/contracts/token/ERC721/IERC721.sol";
 import {IERC721Metadata} from "@openzeppelin/contracts/token/ERC721/extensions/IERC721Metadata.sol";
 
-/// @title CollectionsERC721
+/// @title ERC721EthscriptionsCollection
 /// @notice ERC-721 contract for an Ethscription collection
 /// @dev Maintains internal state but overrides ownerOf to delegate to Ethscriptions contract
-contract CollectionsERC721 is ERC721EthscriptionsEnumerableUpgradeable {
+contract ERC721EthscriptionsCollection is ERC721EthscriptionsEnumerableUpgradeable {
     using LibString for *;
 
     /// @notice The main Ethscriptions contract
@@ -132,8 +132,8 @@ contract CollectionsERC721 is ERC721EthscriptionsEnumerableUpgradeable {
         }
 
         // Get ethscription ID from manager
-        CollectionsProtocolHandler manager = CollectionsProtocolHandler(factory);
-        CollectionsProtocolHandler.CollectionItem memory item = manager.getCollectionItem(collectionId, tokenId);
+        ERC721EthscriptionsCollectionManager manager = ERC721EthscriptionsCollectionManager(factory);
+        ERC721EthscriptionsCollectionManager.CollectionItem memory item = manager.getCollectionItem(collectionId, tokenId);
 
         if (item.ethscriptionId == bytes32(0)) {
             revert("Token not in collection");
@@ -154,9 +154,9 @@ contract CollectionsERC721 is ERC721EthscriptionsEnumerableUpgradeable {
             revert("Token does not exist");
         }
 
-        // Get collection metadata and item data from CollectionsProtocolHandler
-        CollectionsProtocolHandler manager = CollectionsProtocolHandler(factory);
-        CollectionsProtocolHandler.CollectionItem memory item = manager.getCollectionItem(collectionId, tokenId);
+        // Get collection metadata and item data from ERC721EthscriptionsCollectionManager
+        ERC721EthscriptionsCollectionManager manager = ERC721EthscriptionsCollectionManager(factory);
+        ERC721EthscriptionsCollectionManager.CollectionItem memory item = manager.getCollectionItem(collectionId, tokenId);
 
         if (item.ethscriptionId == bytes32(0)) {
             revert("Token not in collection");

--- a/contracts/src/ERC721EthscriptionsCollectionManager.sol
+++ b/contracts/src/ERC721EthscriptionsCollectionManager.sol
@@ -135,12 +135,12 @@ contract ERC721EthscriptionsCollectionManager is IProtocolHandler {
     }
 
     /// @notice Handle create_collection operation
-    function op_create_collection(bytes32 txHash, bytes calldata data) external onlyEthscriptions {
+    function op_create_collection(bytes32 ethscriptionId, bytes calldata data) external onlyEthscriptions {
         // Decode the operation data directly into CollectionMetadata
         CollectionMetadata memory metadata = abi.decode(data, (CollectionMetadata));
 
         // Use the ethscription hash as the collection ID
-        bytes32 collectionId = txHash;
+        bytes32 collectionId = ethscriptionId;
 
         // Check if collection already exists
         require(collectionState[collectionId].collectionContract == address(0), "Collection already exists");
@@ -165,7 +165,7 @@ contract ERC721EthscriptionsCollectionManager is IProtocolHandler {
         // Store collection state
         collectionState[collectionId] = CollectionState({
             collectionContract: address(collectionProxy),
-            createEthscriptionId: txHash,
+            createEthscriptionId: ethscriptionId,
             currentSize: 0,
             locked: false
         });
@@ -179,10 +179,10 @@ contract ERC721EthscriptionsCollectionManager is IProtocolHandler {
     }
 
     /// @notice Handle add_items_batch operation with full metadata
-    function op_add_items_batch(bytes32 txHash, bytes calldata data) external onlyEthscriptions {
+    function op_add_items_batch(bytes32 ethscriptionId, bytes calldata data) external onlyEthscriptions {
         // Get who is trying to add items
         Ethscriptions ethscriptionsContract = Ethscriptions(ethscriptions);
-        Ethscriptions.Ethscription memory ethscription = ethscriptionsContract.getEthscription(txHash);
+        Ethscriptions.Ethscription memory ethscription = ethscriptionsContract.getEthscription(ethscriptionId);
         address sender = ethscription.creator;
 
         AddItemsBatchOperation memory addOp = abi.decode(data, (AddItemsBatchOperation));
@@ -242,14 +242,14 @@ contract ERC721EthscriptionsCollectionManager is IProtocolHandler {
             collection.currentSize++;
         }
 
-        emit ItemsAdded(addOp.collectionId, addOp.items.length, txHash);
+        emit ItemsAdded(addOp.collectionId, addOp.items.length, ethscriptionId);
     }
 
     /// @notice Handle remove_items operation
-    function op_remove_items(bytes32 txHash, bytes calldata data) external onlyEthscriptions {
+    function op_remove_items(bytes32 ethscriptionId, bytes calldata data) external onlyEthscriptions {
         // Get who is trying to remove items
         Ethscriptions ethscriptionsContract = Ethscriptions(ethscriptions);
-        Ethscriptions.Ethscription memory ethscription = ethscriptionsContract.getEthscription(txHash);
+        Ethscriptions.Ethscription memory ethscription = ethscriptionsContract.getEthscription(ethscriptionId);
         address sender = ethscription.creator;
 
         // Decode the operation data
@@ -283,13 +283,13 @@ contract ERC721EthscriptionsCollectionManager is IProtocolHandler {
             collection.currentSize--;
         }
 
-        emit ItemsRemoved(removeOp.collectionId, removeOp.ethscriptionIds.length, txHash);
+        emit ItemsRemoved(removeOp.collectionId, removeOp.ethscriptionIds.length, ethscriptionId);
     }
 
     /// @notice Handle edit_collection operation
-    function op_edit_collection(bytes32 txHash, bytes calldata data) external onlyEthscriptions {
+    function op_edit_collection(bytes32 ethscriptionId, bytes calldata data) external onlyEthscriptions {
         Ethscriptions ethscriptionsContract = Ethscriptions(ethscriptions);
-        Ethscriptions.Ethscription memory ethscription = ethscriptionsContract.getEthscription(txHash);
+        Ethscriptions.Ethscription memory ethscription = ethscriptionsContract.getEthscription(ethscriptionId);
         address sender = ethscription.creator;
 
         EditCollectionOperation memory editOp = abi.decode(data, (EditCollectionOperation));
@@ -315,9 +315,9 @@ contract ERC721EthscriptionsCollectionManager is IProtocolHandler {
     }
 
     /// @notice Handle edit_collection_item operation
-    function op_edit_collection_item(bytes32 txHash, bytes calldata data) external onlyEthscriptions {
+    function op_edit_collection_item(bytes32 ethscriptionId, bytes calldata data) external onlyEthscriptions {
         Ethscriptions ethscriptionsContract = Ethscriptions(ethscriptions);
-        Ethscriptions.Ethscription memory ethscription = ethscriptionsContract.getEthscription(txHash);
+        Ethscriptions.Ethscription memory ethscription = ethscriptionsContract.getEthscription(ethscriptionId);
         address sender = ethscription.creator;
 
         EditCollectionItemOperation memory editOp = abi.decode(data, (EditCollectionItemOperation));
@@ -347,10 +347,10 @@ contract ERC721EthscriptionsCollectionManager is IProtocolHandler {
     }
 
     /// @notice Handle lock_collection operation
-    function op_lock_collection(bytes32 txHash, bytes calldata data) external onlyEthscriptions {
+    function op_lock_collection(bytes32 ethscriptionId, bytes calldata data) external onlyEthscriptions {
         // Get the ethscription details from the Ethscriptions contract
         Ethscriptions ethscriptionsContract = Ethscriptions(ethscriptions);
-        Ethscriptions.Ethscription memory ethscription = ethscriptionsContract.getEthscription(txHash);
+        Ethscriptions.Ethscription memory ethscription = ethscriptionsContract.getEthscription(ethscriptionId);
         address sender = ethscription.creator; // Who sent this lock operation
 
         // Decode just the collection ID
@@ -371,7 +371,7 @@ contract ERC721EthscriptionsCollectionManager is IProtocolHandler {
 
     /// @notice Handle sync_ownership operation to sync ERC721 ownership with Ethscription ownership
     /// @dev Requires specifying the collection ID to sync for, to avoid iterating over unbounded user data
-    function op_sync_ownership(bytes calldata data) external onlyEthscriptions {
+    function op_sync_ownership(bytes32 ethscriptionId, bytes calldata data) external onlyEthscriptions {
         // User must specify which collection to sync for
         // Decode the operation: collection ID + ethscription IDs to sync
         (bytes32 collectionId, bytes32[] memory ethscriptionIds) = abi.decode(data, (bytes32, bytes32[]));

--- a/contracts/src/Ethscriptions.sol
+++ b/contracts/src/Ethscriptions.sol
@@ -44,7 +44,7 @@ contract Ethscriptions is ERC721EthscriptionsSequentialEnumerableUpgradeable {
     }
 
     struct ProtocolParams {
-        string protocolName;  // Protocol identifier (e.g., "erc-20", "collections", etc.)
+        string protocolName;  // Protocol identifier (e.g., "erc-20-fixed-denomination", "erc-721-ethscriptions-collection", etc.)
         string operation;     // Operation to perform (e.g., "mint", "deploy", "create_collection", etc.)
         bytes data;          // ABI-encoded parameters specific to the protocol/operation
     }
@@ -180,7 +180,7 @@ contract Ethscriptions is ERC721EthscriptionsSequentialEnumerableUpgradeable {
     // =============================================================
 
     /// @notice Register a protocol handler
-    /// @param protocol The protocol identifier (e.g., "erc-20", "collections")
+    /// @param protocol The protocol identifier (e.g., "erc-20-fixed-denomination", "erc-721-ethscriptions-collection")
     /// @param handler The address of the handler contract
     /// @dev Only callable by the depositor address (used during genesis setup)
     function registerProtocol(string calldata protocol, address handler) external {

--- a/contracts/src/interfaces/IProtocolHandler.sol
+++ b/contracts/src/interfaces/IProtocolHandler.sol
@@ -16,6 +16,6 @@ interface IProtocolHandler {
     ) external;
 
     /// @notice Returns human-readable protocol name
-    /// @return The protocol name (e.g., "erc-20", "collections")
+    /// @return The protocol name (e.g., "erc-20-fixed-denomination", "erc-721-ethscriptions-collection")
     function protocolName() external pure returns (string memory);
 }

--- a/contracts/src/libraries/Predeploys.sol
+++ b/contracts/src/libraries/Predeploys.sol
@@ -25,26 +25,20 @@ library Predeploys {
     /// @dev Moved to the 0x3300… namespace to align with other Ethscriptions predeploys
     address constant ETHSCRIPTIONS = 0x3300000000000000000000000000000000000001;
     
-    /// @notice FixedFungible protocol handler for managed ERC-20 semantics
-    address constant FIXED_FUNGIBLE_HANDLER = 0x3300000000000000000000000000000000000002;
+    /// @notice ERC20 fixed denomination manager for managed ERC-20 semantics
+    address constant ERC20_FIXED_DENOMINATION_MANAGER = 0x3300000000000000000000000000000000000002;
     
     /// @notice EthscriptionsProver for L1 provability
     address constant ETHSCRIPTIONS_PROVER = 0x3300000000000000000000000000000000000003;
 
-    /// @notice Proxy address reserved for the FixedFungible ERC20 template (blank proxy)
-    address constant FIXED_FUNGIBLE_TEMPLATE_PROXY = 0x3300000000000000000000000000000000000004;
+    /// @notice Implementation address for the ERC20 fixed denomination template (actual logic contract)
+    address constant ERC20_FIXED_DENOMINATION_IMPLEMENTATION = 0xc0D3c0D3c0D3c0d3c0d3C0d3C0d3c0D3C0D30004;
 
-    /// @notice Implementation address for the FixedFungible ERC20 template (actual logic contract)
-    address constant FIXED_FUNGIBLE_TEMPLATE_IMPLEMENTATION = 0xc0D3c0D3c0D3c0d3c0d3C0d3C0d3c0D3C0D30004;
+    /// @notice Implementation address for the ERC721 Ethscriptions collection template (actual logic contract)
+    address constant ERC721_ETHSCRIPTIONS_COLLECTION_IMPLEMENTATION = 0xc0d3C0d3c0D3c0d3C0D3C0D3c0D3C0D3c0d30005;
 
-    /// @notice Proxy address reserved for the Collections ERC721 template (blank proxy)
-    address constant COLLECTIONS_TEMPLATE_PROXY = 0x3300000000000000000000000000000000000005;
-
-    /// @notice Implementation address for the Collections ERC721 template (actual logic contract)
-    address constant COLLECTIONS_TEMPLATE_IMPLEMENTATION = 0xc0d3C0d3c0D3c0d3C0D3C0D3c0D3C0D3c0d30005;
-
-    /// @notice Collections protocol handler
-    address constant COLLECTIONS_PROTOCOL_HANDLER = 0x3300000000000000000000000000000000000006;
+    /// @notice ERC721 Ethscriptions collection manager
+    address constant ERC721_ETHSCRIPTIONS_COLLECTION_MANAGER = 0x3300000000000000000000000000000000000006;
     
     // ============ Helper Functions ============
     

--- a/contracts/test/AddressPrediction.t.sol
+++ b/contracts/test/AddressPrediction.t.sol
@@ -4,21 +4,21 @@ pragma solidity ^0.8.24;
 import "forge-std/Test.sol";
 import "../src/libraries/Predeploys.sol";
 import "../src/libraries/Proxy.sol";
-import "../src/FixedFungibleProtocolHandler.sol";
-import "../src/CollectionsProtocolHandler.sol";
+import "../src/ERC20FixedDenominationManager.sol";
+import "../src/ERC721EthscriptionsCollectionManager.sol";
 import "../src/Ethscriptions.sol";
 import "@openzeppelin/contracts/utils/Create2.sol";
 import "./TestSetup.sol";
 
 contract AddressPredictionTest is TestSetup {
-    // Test predictable address for FixedFungibleProtocolHandler token proxies
-    function testPredictFixedFungibleTokenAddress() public {
+    // Test predictable address for ERC20FixedDenominationManager token proxies
+    function testPredictERC20FixedDenominationTokenAddress() public {
         // Arrange
         string memory tick = "eths";
         bytes32 deployTxHash = keccak256("deploy-eths");
 
         // Prepare deploy op data
-        FixedFungibleProtocolHandler.DeployOperation memory deployOp = FixedFungibleProtocolHandler.DeployOperation({
+        ERC20FixedDenominationManager.DeployOperation memory deployOp = ERC20FixedDenominationManager.DeployOperation({
             tick: tick,
             maxSupply: 1_000_000,
             mintAmount: 1_000
@@ -26,23 +26,23 @@ contract AddressPredictionTest is TestSetup {
         bytes memory data = abi.encode(deployOp);
 
         // Prediction via contract helper
-        address predicted = fixedFungibleHandler.predictTokenAddressByTick(tick);
+        address predicted = fixedDenominationManager.predictTokenAddressByTick(tick);
 
         // Act: call deploy as Ethscriptions (authorized)
         vm.prank(Predeploys.ETHSCRIPTIONS);
-        fixedFungibleHandler.op_deploy(deployTxHash, data);
+        fixedDenominationManager.op_deploy(deployTxHash, data);
 
         // Assert actual matches predicted
-        address actual = fixedFungibleHandler.getTokenAddressByTick(tick);
+        address actual = fixedDenominationManager.getTokenAddressByTick(tick);
         assertEq(actual, predicted, "Predicted token address should match actual deployed proxy");
     }
 
-    // Test predictable address for CollectionsProtocolHandler collection proxies
+    // Test predictable address for ERC721EthscriptionsCollectionManager collection proxies
     function testPredictCollectionsAddress() public {
         // Arrange
         bytes32 collectionId = keccak256("collection-1");
 
-        CollectionsProtocolHandler.CollectionMetadata memory metadata = CollectionsProtocolHandler.CollectionMetadata({
+        ERC721EthscriptionsCollectionManager.CollectionMetadata memory metadata = ERC721EthscriptionsCollectionManager.CollectionMetadata({
             name: "My Collection",
             symbol: "MYC",
             totalSupply: 1000,

--- a/contracts/test/CollectionsProtocol.t.sol
+++ b/contracts/test/CollectionsProtocol.t.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8.24;
 
 import "forge-std/Test.sol";
-import "../src/CollectionsProtocolHandler.sol";
+import "../src/ERC721EthscriptionsCollectionManager.sol";
 import "../src/Ethscriptions.sol";
 import "../src/libraries/Predeploys.sol";
 import "./TestSetup.sol";
@@ -12,7 +12,7 @@ contract CollectionsProtocolTest is TestSetup {
     
     function test_CreateCollection() public {
         // Encode collection metadata as ABI tuple
-        CollectionsProtocolHandler.CollectionMetadata memory metadata = CollectionsProtocolHandler.CollectionMetadata({
+        ERC721EthscriptionsCollectionManager.CollectionMetadata memory metadata = ERC721EthscriptionsCollectionManager.CollectionMetadata({
             name: "Test Collection",
             symbol: "TEST",
             totalSupply: 100,
@@ -37,14 +37,14 @@ contract CollectionsProtocolTest is TestSetup {
         bytes32 collectionId = txHash;
 
         // Use the getter functions instead of direct mapping access
-        CollectionsProtocolHandler.CollectionState memory state = collectionsHandler.getCollectionState(collectionId);
+        ERC721EthscriptionsCollectionManager.CollectionState memory state = collectionsHandler.getCollectionState(collectionId);
         assertNotEq(state.collectionContract, address(0), "Collection contract should be deployed");
         assertEq(state.createEthscriptionId, txHash, "Create ethscription ID should match");
         assertEq(state.currentSize, 0, "Initial size should be 0");
         assertEq(state.locked, false, "Should not be locked");
 
         // Verify metadata
-        CollectionsProtocolHandler.CollectionMetadata memory storedMetadata = collectionsHandler.getCollectionMetadata(collectionId);
+        ERC721EthscriptionsCollectionManager.CollectionMetadata memory storedMetadata = collectionsHandler.getCollectionMetadata(collectionId);
         assertEq(storedMetadata.name, "Test Collection", "Name should match");
         assertEq(storedMetadata.symbol, "TEST", "Symbol should match");
         assertEq(storedMetadata.totalSupply, 100, "Total supply should match");
@@ -55,10 +55,10 @@ contract CollectionsProtocolTest is TestSetup {
         // Full end-to-end test: create ethscription with JSON, let it call the protocol handler
 
         // The JSON data
-        string memory json = '{"p":"collections","op":"create_collection","name":"Test NFTs","symbol":"TEST","totalSupply":"100","description":"","logoImageUri":"","bannerImageUri":"","backgroundColor":"","websiteLink":"","twitterLink":"","discordLink":""}';
+        string memory json = '{"p":"erc-721-ethscriptions-collection","op":"create_collection","name":"Test NFTs","symbol":"TEST","totalSupply":"100","description":"","logoImageUri":"","bannerImageUri":"","backgroundColor":"","websiteLink":"","twitterLink":"","discordLink":""}';
 
         // Encode the metadata as the protocol handler expects
-        CollectionsProtocolHandler.CollectionMetadata memory metadata = CollectionsProtocolHandler.CollectionMetadata({
+        ERC721EthscriptionsCollectionManager.CollectionMetadata memory metadata = ERC721EthscriptionsCollectionManager.CollectionMetadata({
             name: "Test NFTs",
             symbol: "TEST",
             totalSupply: 100,
@@ -84,7 +84,7 @@ contract CollectionsProtocolTest is TestSetup {
             mimetype: "application/json",
             esip6: false,
             protocolParams: Ethscriptions.ProtocolParams({
-                protocolName: "collections",
+                protocolName: "erc-721-ethscriptions-collection",
                 operation: "create_collection",
                 data: encodedProtocolData
             })
@@ -97,7 +97,7 @@ contract CollectionsProtocolTest is TestSetup {
         bytes32 collectionId = txHash;
 
         // Read back the state
-        CollectionsProtocolHandler.CollectionState memory state = collectionsHandler.getCollectionState(collectionId);
+        ERC721EthscriptionsCollectionManager.CollectionState memory state = collectionsHandler.getCollectionState(collectionId);
 
         console.log("Collection exists:", state.collectionContract != address(0));
         console.log("Collection contract:", state.collectionContract);
@@ -110,7 +110,7 @@ contract CollectionsProtocolTest is TestSetup {
         assertEq(state.locked, false);
 
         // Read metadata
-        CollectionsProtocolHandler.CollectionMetadata memory storedMetadata = collectionsHandler.getCollectionMetadata(collectionId);
+        ERC721EthscriptionsCollectionManager.CollectionMetadata memory storedMetadata = collectionsHandler.getCollectionMetadata(collectionId);
         assertEq(storedMetadata.name, "Test NFTs");
         assertEq(storedMetadata.symbol, "TEST");
         assertEq(storedMetadata.totalSupply, 100);
@@ -118,7 +118,7 @@ contract CollectionsProtocolTest is TestSetup {
 
     function test_ReadCollectionStateViaEthCall() public {
         // Create a collection first
-        CollectionsProtocolHandler.CollectionMetadata memory metadata = CollectionsProtocolHandler.CollectionMetadata({
+        ERC721EthscriptionsCollectionManager.CollectionMetadata memory metadata = ERC721EthscriptionsCollectionManager.CollectionMetadata({
             name: "Call Test",
             symbol: "CALL",
             totalSupply: 50,
@@ -156,7 +156,7 @@ contract CollectionsProtocolTest is TestSetup {
         console.logBytes(result);
 
         // Decode the result
-        CollectionsProtocolHandler.CollectionState memory state = abi.decode(result, (CollectionsProtocolHandler.CollectionState));
+        ERC721EthscriptionsCollectionManager.CollectionState memory state = abi.decode(result, (ERC721EthscriptionsCollectionManager.CollectionState));
 
         assertTrue(state.collectionContract != address(0), "Should have collection contract");
         assertEq(state.createEthscriptionId, txHash);

--- a/contracts/test/EthscriptionsBurn.t.sol
+++ b/contracts/test/EthscriptionsBurn.t.sol
@@ -138,7 +138,7 @@ contract EthscriptionsBurnTest is TestSetup {
         assertEq(ethscriptions.ownerOf(tokenId), alice);
     }
     
-    function testBurnCallsFixedFungibleProtocolHandlerHandleTransfer() public {
+    function testBurnCallsERC20FixedDenominationManagerHandleTransfer() public {
         // Create a simple non-token ethscription first to test basic burn
         bytes32 simpleTxHash = keccak256("simple_tx");
         Ethscriptions.CreateEthscriptionParams memory params = createTestParams(
@@ -160,7 +160,7 @@ contract EthscriptionsBurnTest is TestSetup {
         // Verify it's owned by address(0)
         assertEq(ethscriptions.ownerOf(simpleTokenId), address(0));
 
-        // The transfer should have called FixedFungibleProtocolHandler.handleTokenTransfer with to=address(0)
-        // This ensures FixedFungibleProtocolHandler is notified of transfers to null address
+        // The transfer should have called ERC20FixedDenominationManager.handleTokenTransfer with to=address(0)
+        // This ensures ERC20FixedDenominationManager is notified of transfers to null address
     }
 }

--- a/contracts/test/EthscriptionsToken.t.sol
+++ b/contracts/test/EthscriptionsToken.t.sol
@@ -5,7 +5,7 @@ import "./TestSetup.sol";
 import "@openzeppelin/contracts-upgradeable/token/ERC20/extensions/ERC20CappedUpgradeable.sol";
 
 contract EthscriptionsTokenTest is TestSetup {
-    string constant CANONICAL_PROTOCOL = "fixed-fungible";
+    string constant CANONICAL_PROTOCOL = "erc-20-fixed-denomination";
     address alice = address(0x1);
     address bob = address(0x2);
     address charlie = address(0x3);
@@ -68,7 +68,7 @@ contract EthscriptionsTokenTest is TestSetup {
         string memory deployContent = 'data:,{"p":"erc-20","op":"deploy","tick":"TEST","max":"1000000","lim":"1000"}';
 
         // For deploy operation, encode the deploy params
-        FixedFungibleProtocolHandler.DeployOperation memory deployOp = FixedFungibleProtocolHandler.DeployOperation({
+        ERC20FixedDenominationManager.DeployOperation memory deployOp = ERC20FixedDenominationManager.DeployOperation({
             tick: "TEST",
             maxSupply: 1000000,
             mintAmount: 1000
@@ -86,7 +86,7 @@ contract EthscriptionsTokenTest is TestSetup {
         ethscriptions.createEthscription(params);
         
         // Verify token was deployed
-        FixedFungibleProtocolHandler.TokenInfo memory tokenInfo = fixedFungibleHandler.getTokenInfo(DEPLOY_TX_HASH);
+        ERC20FixedDenominationManager.TokenInfo memory tokenInfo = fixedDenominationManager.getTokenInfo(DEPLOY_TX_HASH);
             
         assertEq(tokenInfo.tick, "TEST");
         assertEq(tokenInfo.maxSupply, 1000000);
@@ -109,7 +109,7 @@ contract EthscriptionsTokenTest is TestSetup {
         string memory mintContent = 'data:,{"p":"erc-20","op":"mint","tick":"TEST","id":"1","amt":"1000"}';
 
         // For mint operation, encode the mint params
-        FixedFungibleProtocolHandler.MintOperation memory mintOp = FixedFungibleProtocolHandler.MintOperation({
+        ERC20FixedDenominationManager.MintOperation memory mintOp = ERC20FixedDenominationManager.MintOperation({
             tick: "TEST",
             id: 1,
             amount: 1000
@@ -131,12 +131,12 @@ contract EthscriptionsTokenTest is TestSetup {
         assertEq(ethscriptions.ownerOf(mintEthscription.ethscriptionNumber), bob);
         
         // Verify Bob has the tokens (1000 * 10^18 with 18 decimals)
-        address tokenAddress = fixedFungibleHandler.getTokenAddressByTick("TEST");
-        FixedFungibleERC20 token = FixedFungibleERC20(tokenAddress);
+        address tokenAddress = fixedDenominationManager.getTokenAddressByTick("TEST");
+        ERC20FixedDenomination token = ERC20FixedDenomination(tokenAddress);
         assertEq(token.balanceOf(bob), 1000 ether);  // 1000 * 10^18
         
         // Verify total minted increased
-        FixedFungibleProtocolHandler.TokenInfo memory info = fixedFungibleHandler.getTokenInfo(DEPLOY_TX_HASH);
+        ERC20FixedDenominationManager.TokenInfo memory info = fixedDenominationManager.getTokenInfo(DEPLOY_TX_HASH);
         assertEq(info.totalMinted, 1000);
     }
     
@@ -144,8 +144,8 @@ contract EthscriptionsTokenTest is TestSetup {
         // Setup: Deploy and mint
         testTokenMint();
         
-        address tokenAddress = fixedFungibleHandler.getTokenAddressByTick("TEST");
-        FixedFungibleERC20 token = FixedFungibleERC20(tokenAddress);
+        address tokenAddress = fixedDenominationManager.getTokenAddressByTick("TEST");
+        ERC20FixedDenomination token = ERC20FixedDenomination(tokenAddress);
         
         // Bob transfers the NFT to Charlie
         vm.prank(bob);
@@ -164,13 +164,13 @@ contract EthscriptionsTokenTest is TestSetup {
         // Deploy the token
         testTokenDeploy();
         
-        address tokenAddress = fixedFungibleHandler.getTokenAddressByTick("TEST");
-        FixedFungibleERC20 token = FixedFungibleERC20(tokenAddress);
+        address tokenAddress = fixedDenominationManager.getTokenAddressByTick("TEST");
+        ERC20FixedDenomination token = ERC20FixedDenomination(tokenAddress);
         
         // Bob mints tokens
         vm.prank(bob);
         string memory mintContent1 = 'data:,{"p":"erc-20","op":"mint","tick":"TEST","id":"1","amt":"1000"}';
-        FixedFungibleProtocolHandler.MintOperation memory mintOp1 = FixedFungibleProtocolHandler.MintOperation({
+        ERC20FixedDenominationManager.MintOperation memory mintOp1 = ERC20FixedDenominationManager.MintOperation({
             tick: "TEST",
             id: 1,
             amount: 1000
@@ -187,7 +187,7 @@ contract EthscriptionsTokenTest is TestSetup {
         // Charlie mints tokens
         vm.prank(charlie);
         string memory mintContent2 = 'data:,{"p":"erc-20","op":"mint","tick":"TEST","id":"2","amt":"1000"}';
-        FixedFungibleProtocolHandler.MintOperation memory mintOp2 = FixedFungibleProtocolHandler.MintOperation({
+        ERC20FixedDenominationManager.MintOperation memory mintOp2 = ERC20FixedDenominationManager.MintOperation({
             tick: "TEST",
             id: 2,
             amount: 1000
@@ -206,7 +206,7 @@ contract EthscriptionsTokenTest is TestSetup {
         assertEq(token.balanceOf(charlie), 1000 ether);
         
         // Verify total minted
-        FixedFungibleProtocolHandler.TokenInfo memory info = fixedFungibleHandler.getTokenInfo(DEPLOY_TX_HASH);
+        ERC20FixedDenominationManager.TokenInfo memory info = fixedDenominationManager.getTokenInfo(DEPLOY_TX_HASH);
         assertEq(info.totalMinted, 2000);
     }
     
@@ -217,7 +217,7 @@ contract EthscriptionsTokenTest is TestSetup {
         bytes32 smallDeployHash = bytes32(uint256(0xDEAD));
         string memory deployContent = 'data:,{"p":"erc-20","op":"deploy","tick":"SMALL","max":"2000","lim":"1000"}';
         
-        FixedFungibleProtocolHandler.DeployOperation memory smallDeployOp = FixedFungibleProtocolHandler.DeployOperation({
+        ERC20FixedDenominationManager.DeployOperation memory smallDeployOp = ERC20FixedDenominationManager.DeployOperation({
             tick: "SMALL",
             maxSupply: 2000,
             mintAmount: 1000
@@ -234,7 +234,7 @@ contract EthscriptionsTokenTest is TestSetup {
         
         // Mint up to max supply
         vm.prank(bob);
-        FixedFungibleProtocolHandler.MintOperation memory mintOp1Small = FixedFungibleProtocolHandler.MintOperation({
+        ERC20FixedDenominationManager.MintOperation memory mintOp1Small = ERC20FixedDenominationManager.MintOperation({
             tick: "SMALL",
             id: 1,
             amount: 1000
@@ -249,7 +249,7 @@ contract EthscriptionsTokenTest is TestSetup {
         ));
         
         vm.prank(charlie);
-        FixedFungibleProtocolHandler.MintOperation memory mintOp2Small = FixedFungibleProtocolHandler.MintOperation({
+        ERC20FixedDenominationManager.MintOperation memory mintOp2Small = ERC20FixedDenominationManager.MintOperation({
             tick: "SMALL",
             id: 2,
             amount: 1000
@@ -265,7 +265,7 @@ contract EthscriptionsTokenTest is TestSetup {
         
         // Try to mint beyond max supply - should fail silently with event
         bytes32 exceedTxHash = bytes32(uint256(0xBEEF3));
-        FixedFungibleProtocolHandler.MintOperation memory exceedMintOp = FixedFungibleProtocolHandler.MintOperation({
+        ERC20FixedDenominationManager.MintOperation memory exceedMintOp = ERC20FixedDenominationManager.MintOperation({
             tick: "SMALL",
             id: 3,
             amount: 1000
@@ -288,8 +288,8 @@ contract EthscriptionsTokenTest is TestSetup {
         assertEq(ethscriptions.ownerOf(tokenId), alice);
 
         // Verify supply didn't increase
-        address tokenAddress = fixedFungibleHandler.getTokenAddressByTick("SMALL");
-        FixedFungibleERC20 token = FixedFungibleERC20(tokenAddress);
+        address tokenAddress = fixedDenominationManager.getTokenAddressByTick("SMALL");
+        ERC20FixedDenomination token = ERC20FixedDenomination(tokenAddress);
         assertEq(token.totalSupply(), 2000 ether); // Should still be at max
     }
     
@@ -297,24 +297,24 @@ contract EthscriptionsTokenTest is TestSetup {
         // Setup
         testTokenMint();
         
-        address tokenAddress = fixedFungibleHandler.getTokenAddressByTick("TEST");
-        FixedFungibleERC20 token = FixedFungibleERC20(tokenAddress);
+        address tokenAddress = fixedDenominationManager.getTokenAddressByTick("TEST");
+        ERC20FixedDenomination token = ERC20FixedDenomination(tokenAddress);
         
         // Bob tries to transfer tokens directly (not via NFT) - should revert
         vm.prank(bob);
-        vm.expectRevert(FixedFungibleERC20.TransfersOnlyViaEthscriptions.selector);
+        vm.expectRevert(ERC20FixedDenomination.TransfersOnlyViaEthscriptions.selector);
         token.transfer(charlie, 500);
     }
     
     function testTokenAddressPredictability() public {
         // Predict the token address before deployment
-        address predictedAddress = fixedFungibleHandler.predictTokenAddressByTick("TEST");
+        address predictedAddress = fixedDenominationManager.predictTokenAddressByTick("TEST");
         
         // Deploy the token
         testTokenDeploy();
         
         // Verify the actual address matches prediction
-        address actualAddress = fixedFungibleHandler.getTokenAddressByTick("TEST");
+        address actualAddress = fixedDenominationManager.getTokenAddressByTick("TEST");
         assertEq(actualAddress, predictedAddress);
     }
     
@@ -326,7 +326,7 @@ contract EthscriptionsTokenTest is TestSetup {
         string memory wrongAmountContent = 'data:,{"p":"erc-20","op":"mint","tick":"TEST","id":"1","amt":"500"}';
 
         bytes32 wrongTxHash = bytes32(uint256(0xBAD));
-        FixedFungibleProtocolHandler.MintOperation memory wrongMintOp = FixedFungibleProtocolHandler.MintOperation({
+        ERC20FixedDenominationManager.MintOperation memory wrongMintOp = ERC20FixedDenominationManager.MintOperation({
             tick: "TEST",
             id: 1,
             amount: 500  // Wrong - should be 1000 to match lim
@@ -349,8 +349,8 @@ contract EthscriptionsTokenTest is TestSetup {
         assertEq(ethscriptions.ownerOf(tokenId), bob);
 
         // Verify no tokens were minted
-        address tokenAddr = fixedFungibleHandler.getTokenAddressByTick("TEST");
-        FixedFungibleERC20 token = FixedFungibleERC20(tokenAddr);
+        address tokenAddr = fixedDenominationManager.getTokenAddressByTick("TEST");
+        ERC20FixedDenomination token = ERC20FixedDenomination(tokenAddr);
         assertEq(token.balanceOf(bob), 0); // Bob should have no tokens
     }
     
@@ -363,7 +363,7 @@ contract EthscriptionsTokenTest is TestSetup {
         string memory deployContent = 'data:,{"p":"erc-20","op":"deploy","tick":"TEST","max":"2000000","lim":"2000"}';
 
         bytes32 duplicateTxHash = bytes32(uint256(0xABCD));
-        FixedFungibleProtocolHandler.DeployOperation memory duplicateDeployOp = FixedFungibleProtocolHandler.DeployOperation({
+        ERC20FixedDenominationManager.DeployOperation memory duplicateDeployOp = ERC20FixedDenominationManager.DeployOperation({
             tick: "TEST",
             maxSupply: 2000000,  // Different parameters but same tick
             mintAmount: 2000
@@ -387,9 +387,9 @@ contract EthscriptionsTokenTest is TestSetup {
         assertEq(ethscriptions.ownerOf(tokenId), alice);
 
         // Verify the original token is still the only one
-        address tokenAddr = fixedFungibleHandler.getTokenAddressByTick("TEST");
-        FixedFungibleERC20 token = FixedFungibleERC20(tokenAddr);
-        assertEq(token.name(), "Fixed-Fungible TEST");  // Token name format is "protocol tick"
+        address tokenAddr = fixedDenominationManager.getTokenAddressByTick("TEST");
+        ERC20FixedDenomination token = ERC20FixedDenomination(tokenAddr);
+        assertEq(token.name(), "TEST");  // Token name format is "protocol tick"
         assertEq(token.maxSupply(), 1000000 ether); // Original cap (maxSupply), not the duplicate's
     }
 
@@ -401,7 +401,7 @@ contract EthscriptionsTokenTest is TestSetup {
         vm.prank(bob);
         string memory mintContent = 'data:,{"p":"erc-20","op":"mint","tick":"TEST","id":"0","amt":"1000"}';
 
-        FixedFungibleProtocolHandler.MintOperation memory mintOp = FixedFungibleProtocolHandler.MintOperation({
+        ERC20FixedDenominationManager.MintOperation memory mintOp = ERC20FixedDenominationManager.MintOperation({
             tick: "TEST",
             id: 0, // Invalid ID - should be >= 1
             amount: 1000
@@ -424,12 +424,12 @@ contract EthscriptionsTokenTest is TestSetup {
         assertEq(ethscriptions.ownerOf(tokenId), bob);
 
         // Verify no tokens were minted due to invalid ID
-        address tokenAddr = fixedFungibleHandler.getTokenAddressByTick("TEST");
-        FixedFungibleERC20 token = FixedFungibleERC20(tokenAddr);
+        address tokenAddr = fixedDenominationManager.getTokenAddressByTick("TEST");
+        ERC20FixedDenomination token = ERC20FixedDenomination(tokenAddr);
         assertEq(token.balanceOf(bob), 0); // Bob should have no tokens
 
         // Verify total minted didn't increase
-        FixedFungibleProtocolHandler.TokenInfo memory info = fixedFungibleHandler.getTokenInfo(DEPLOY_TX_HASH);
+        ERC20FixedDenominationManager.TokenInfo memory info = fixedDenominationManager.getTokenInfo(DEPLOY_TX_HASH);
         assertEq(info.totalMinted, 0);
     }
 
@@ -441,7 +441,7 @@ contract EthscriptionsTokenTest is TestSetup {
         vm.prank(bob);
         string memory mintContent = 'data:,{"p":"erc-20","op":"mint","tick":"TEST","id":"1001","amt":"1000"}';
 
-        FixedFungibleProtocolHandler.MintOperation memory mintOp = FixedFungibleProtocolHandler.MintOperation({
+        ERC20FixedDenominationManager.MintOperation memory mintOp = ERC20FixedDenominationManager.MintOperation({
             tick: "TEST",
             id: 1001, // Invalid ID - maxId is 1000
             amount: 1000
@@ -464,12 +464,12 @@ contract EthscriptionsTokenTest is TestSetup {
         assertEq(ethscriptions.ownerOf(tokenId), bob);
 
         // Verify no tokens were minted due to invalid ID
-        address tokenAddr = fixedFungibleHandler.getTokenAddressByTick("TEST");
-        FixedFungibleERC20 token = FixedFungibleERC20(tokenAddr);
+        address tokenAddr = fixedDenominationManager.getTokenAddressByTick("TEST");
+        ERC20FixedDenomination token = ERC20FixedDenomination(tokenAddr);
         assertEq(token.balanceOf(bob), 0); // Bob should have no tokens
 
         // Verify total minted didn't increase
-        FixedFungibleProtocolHandler.TokenInfo memory info = fixedFungibleHandler.getTokenInfo(DEPLOY_TX_HASH);
+        ERC20FixedDenominationManager.TokenInfo memory info = fixedDenominationManager.getTokenInfo(DEPLOY_TX_HASH);
         assertEq(info.totalMinted, 0);
     }
 
@@ -481,7 +481,7 @@ contract EthscriptionsTokenTest is TestSetup {
         vm.prank(bob);
         string memory mintContent = 'data:,{"p":"erc-20","op":"mint","tick":"TEST","id":"1000","amt":"1000"}';
 
-        FixedFungibleProtocolHandler.MintOperation memory mintOp = FixedFungibleProtocolHandler.MintOperation({
+        ERC20FixedDenominationManager.MintOperation memory mintOp = ERC20FixedDenominationManager.MintOperation({
             tick: "TEST",
             id: 1000, // Maximum valid ID
             amount: 1000
@@ -503,12 +503,12 @@ contract EthscriptionsTokenTest is TestSetup {
         assertEq(ethscriptions.ownerOf(tokenId), bob);
 
         // Verify Bob has the tokens (1000 * 10^18 with 18 decimals)
-        address tokenAddr = fixedFungibleHandler.getTokenAddressByTick("TEST");
-        FixedFungibleERC20 token = FixedFungibleERC20(tokenAddr);
+        address tokenAddr = fixedDenominationManager.getTokenAddressByTick("TEST");
+        ERC20FixedDenomination token = ERC20FixedDenomination(tokenAddr);
         assertEq(token.balanceOf(bob), 1000 ether); // Should have tokens
 
         // Verify total minted increased
-        FixedFungibleProtocolHandler.TokenInfo memory info = fixedFungibleHandler.getTokenInfo(DEPLOY_TX_HASH);
+        ERC20FixedDenominationManager.TokenInfo memory info = fixedDenominationManager.getTokenInfo(DEPLOY_TX_HASH);
         assertEq(info.totalMinted, 1000);
     }
 
@@ -520,7 +520,7 @@ contract EthscriptionsTokenTest is TestSetup {
         bytes32 nullMintTx = bytes32(uint256(0xBADD0));
         string memory mintContent = 'data:,{"p":"erc-20","op":"mint","tick":"TEST","id":"1","amt":"1000"}';
 
-        FixedFungibleProtocolHandler.MintOperation memory mintOp = FixedFungibleProtocolHandler.MintOperation({
+        ERC20FixedDenominationManager.MintOperation memory mintOp = ERC20FixedDenominationManager.MintOperation({
             tick: "TEST",
             id: 1,
             amount: 1000
@@ -543,14 +543,14 @@ contract EthscriptionsTokenTest is TestSetup {
         assertEq(ethscriptions.ownerOf(tokenId), address(0));
 
         // ERC20 should be minted and credited to the null address
-        address tokenAddr = fixedFungibleHandler.getTokenAddressByTick("TEST");
-        FixedFungibleERC20 token = FixedFungibleERC20(tokenAddr);
+        address tokenAddr = fixedDenominationManager.getTokenAddressByTick("TEST");
+        ERC20FixedDenomination token = ERC20FixedDenomination(tokenAddr);
         assertEq(token.totalSupply(), 1000 ether);
         assertEq(token.balanceOf(address(0)), 1000 ether);
 
-        // FixedFungibleProtocolHandler should record a token item and increase total minted
-        assertTrue(fixedFungibleHandler.isTokenItem(nullMintTx));
-        FixedFungibleProtocolHandler.TokenInfo memory info = fixedFungibleHandler.getTokenInfo(DEPLOY_TX_HASH);
+        // ERC20FixedDenominationManager should record a token item and increase total minted
+        assertTrue(fixedDenominationManager.isTokenItem(nullMintTx));
+        ERC20FixedDenominationManager.TokenInfo memory info = fixedDenominationManager.getTokenInfo(DEPLOY_TX_HASH);
         assertEq(info.totalMinted, 1000);
     }
 
@@ -558,8 +558,8 @@ contract EthscriptionsTokenTest is TestSetup {
         // Setup: deploy and mint a token item to Bob
         testTokenMint();
 
-        address tokenAddr = fixedFungibleHandler.getTokenAddressByTick("TEST");
-        FixedFungibleERC20 token = FixedFungibleERC20(tokenAddr);
+        address tokenAddr = fixedDenominationManager.getTokenAddressByTick("TEST");
+        ERC20FixedDenomination token = ERC20FixedDenomination(tokenAddr);
 
         // Sanity: Bob has the ERC20 minted via the token item
         assertEq(token.balanceOf(bob), 1000 ether);

--- a/contracts/test/EthscriptionsTokenParams.t.sol
+++ b/contracts/test/EthscriptionsTokenParams.t.sol
@@ -5,7 +5,7 @@ import "./TestSetup.sol";
 import "forge-std/console.sol";
 
 contract EthscriptionsTokenParamsTest is TestSetup {
-    string constant CANONICAL_PROTOCOL = "fixed-fungible";
+    string constant CANONICAL_PROTOCOL = "erc-20-fixed-denomination";
 
     function testCreateWithTokenDeployParams() public {
         // Create a token deploy ethscription
@@ -13,7 +13,7 @@ contract EthscriptionsTokenParamsTest is TestSetup {
         string memory dataUri = string.concat("data:,", tokenJson);
         bytes32 contentUriHash = sha256(bytes(dataUri));
 
-        FixedFungibleProtocolHandler.DeployOperation memory deployOp = FixedFungibleProtocolHandler.DeployOperation({
+        ERC20FixedDenominationManager.DeployOperation memory deployOp = ERC20FixedDenominationManager.DeployOperation({
             tick: "eths",
             maxSupply: 21000000,
             mintAmount: 1000
@@ -51,7 +51,7 @@ contract EthscriptionsTokenParamsTest is TestSetup {
         string memory dataUri = string.concat("data:,", tokenJson);
         bytes32 contentUriHash = sha256(bytes(dataUri));
 
-        FixedFungibleProtocolHandler.MintOperation memory mintOp = FixedFungibleProtocolHandler.MintOperation({
+        ERC20FixedDenominationManager.MintOperation memory mintOp = ERC20FixedDenominationManager.MintOperation({
             tick: "eths",
             id: 1,
             amount: 1000
@@ -105,13 +105,13 @@ contract EthscriptionsTokenParamsTest is TestSetup {
         assertEq(ethscriptions.totalSupply(), 12, "Should have created new ethscription");
     }
 
-    function testFixedFungibleProtocolHandlerIntegration() public {
+    function testERC20FixedDenominationManagerIntegration() public {
         // First create a deploy operation
         string memory deployJson = '{"p":"erc-20","op":"deploy","tick":"test","max":"1000000","lim":"100"}';
         string memory deployUri = string.concat("data:,", deployJson);
 
 
-        FixedFungibleProtocolHandler.DeployOperation memory deployOp = FixedFungibleProtocolHandler.DeployOperation({
+        ERC20FixedDenominationManager.DeployOperation memory deployOp = ERC20FixedDenominationManager.DeployOperation({
             tick: "test",
             maxSupply: 1000000,
             mintAmount: 100
@@ -137,7 +137,7 @@ contract EthscriptionsTokenParamsTest is TestSetup {
         string memory mintJson = '{"p":"erc-20","op":"mint","tick":"test","id":"1","amt":"100"}';
         string memory mintUri = string.concat("data:,", mintJson);
 
-        FixedFungibleProtocolHandler.MintOperation memory mintOp = FixedFungibleProtocolHandler.MintOperation({
+        ERC20FixedDenominationManager.MintOperation memory mintOp = ERC20FixedDenominationManager.MintOperation({
             tick: "test",
             id: 1,
             amount: 100

--- a/contracts/test/ProtocolRegistration.t.sol
+++ b/contracts/test/ProtocolRegistration.t.sol
@@ -95,11 +95,11 @@ contract ProtocolRegistrationTest is TestSetup {
 
     /// @notice Test that pre-registered protocols (erc-20, collections) are already set
     function testPreRegisteredProtocols() public {
-        // Verify fixed-fungible is registered to FixedFungibleProtocolHandler
-        assertEq(ethscriptions.protocolHandlers("fixed-fungible"), Predeploys.FIXED_FUNGIBLE_HANDLER);
+        // Verify fixed denomination protocol maps to ERC20FixedDenominationManager
+        assertEq(ethscriptions.protocolHandlers("erc-20-fixed-denomination"), Predeploys.ERC20_FIXED_DENOMINATION_MANAGER);
 
-        // Verify collections is registered to CollectionsProtocolHandler
-        assertEq(ethscriptions.protocolHandlers("collections"), Predeploys.COLLECTIONS_PROTOCOL_HANDLER);
+        // Verify collections is registered to ERC721EthscriptionsCollectionManager
+        assertEq(ethscriptions.protocolHandlers("erc-721-ethscriptions-collection"), Predeploys.ERC721_ETHSCRIPTIONS_COLLECTION_MANAGER);
     }
 
     /// @notice Test that ethscriptions with registered protocol call the handler on transfer

--- a/contracts/test/TestSetup.sol
+++ b/contracts/test/TestSetup.sol
@@ -3,10 +3,10 @@ pragma solidity ^0.8.24;
 
 import "forge-std/Test.sol";
 import "../src/Ethscriptions.sol";
-import "../src/FixedFungibleProtocolHandler.sol";
-import "../src/CollectionsProtocolHandler.sol";
+import "../src/ERC20FixedDenominationManager.sol";
+import "../src/ERC721EthscriptionsCollectionManager.sol";
 import "../src/EthscriptionsProver.sol";
-import "../src/FixedFungibleERC20.sol";
+import "../src/ERC20FixedDenomination.sol";
 import "../src/L2/L2ToL1MessagePasser.sol";
 import "../src/L2/L1Block.sol";
 import {Base64} from "solady/utils/Base64.sol";
@@ -17,28 +17,12 @@ import "../script/L2Genesis.s.sol";
 /// @notice Base test contract that pre-deploys all system contracts at their known addresses
 abstract contract TestSetup is Test {
     Ethscriptions public ethscriptions;
-    FixedFungibleProtocolHandler public fixedFungibleHandler;
-    CollectionsProtocolHandler public collectionsHandler;
+    ERC20FixedDenominationManager public fixedDenominationManager;
+    ERC721EthscriptionsCollectionManager public collectionsHandler;
     EthscriptionsProver public prover;
     L1Block public l1Block;
     
     function setUp() public virtual {
-        // Deploy all system contracts to temporary addresses first
-        // Ethscriptions tempEthscriptions = new Ethscriptions();
-        // FixedFungibleProtocolHandler tempFixedFungibleProtocolHandler = new FixedFungibleProtocolHandler();
-        // EthscriptionsProver tempProver = new EthscriptionsProver();
-        // FixedFungibleERC20 tempERC20Template = new FixedFungibleERC20();
-        // L2ToL1MessagePasser tempMessagePasser = new L2ToL1MessagePasser();
-        // L1Block tempL1Block = new L1Block();
-        
-        // // Etch them at their known addresses
-        // vm.etch(Predeploys.ETHSCRIPTIONS, address(tempEthscriptions).code);
-        // vm.etch(Predeploys.FIXED_FUNGIBLE_HANDLER, address(tempFixedFungibleProtocolHandler).code);
-        // vm.etch(Predeploys.ETHSCRIPTIONS_PROVER, address(tempProver).code);
-        // vm.etch(Predeploys.FIXED_FUNGIBLE_TEMPLATE_IMPLEMENTATION, address(tempERC20Template).code);
-        // vm.etch(Predeploys.L2_TO_L1_MESSAGE_PASSER, address(tempMessagePasser).code);
-        // vm.etch(Predeploys.L1_BLOCK_ATTRIBUTES, address(tempL1Block).code);
-        
         L2Genesis genesis = new L2Genesis();
         genesis.runWithoutDump();
         
@@ -47,8 +31,8 @@ abstract contract TestSetup is Test {
         ethscriptions = Ethscriptions(Predeploys.ETHSCRIPTIONS);
         
         // Store contract references for tests
-        fixedFungibleHandler = FixedFungibleProtocolHandler(Predeploys.FIXED_FUNGIBLE_HANDLER);
-        collectionsHandler = CollectionsProtocolHandler(Predeploys.COLLECTIONS_PROTOCOL_HANDLER);
+        fixedDenominationManager = ERC20FixedDenominationManager(Predeploys.ERC20_FIXED_DENOMINATION_MANAGER);
+        collectionsHandler = ERC721EthscriptionsCollectionManager(Predeploys.ERC721_ETHSCRIPTIONS_COLLECTION_MANAGER);
         prover = EthscriptionsProver(Predeploys.ETHSCRIPTIONS_PROVER);
         l1Block = L1Block(Predeploys.L1_BLOCK_ATTRIBUTES);
 

--- a/lib/erc20_fixed_denomination_reader.rb
+++ b/lib/erc20_fixed_denomination_reader.rb
@@ -124,13 +124,6 @@ class Erc20FixedDenominationReader
     nil
   end
 
-  # Legacy compatibility - mints aren't tracked by ID in ERC20FixedDenominationManager
-  def self.get_mint(tick, mint_id, block_tag: 'latest')
-    # This would need to be reimplemented if mint tracking by ID is needed
-    # For now, return nil as ERC20FixedDenominationManager doesn't support this
-    nil
-  end
-
   def self.mint_exists?(tick, mint_id, block_tag: 'latest')
     # ERC20FixedDenominationManager doesn't track mints by tick+id
     false

--- a/lib/erc20_fixed_denomination_reader.rb
+++ b/lib/erc20_fixed_denomination_reader.rb
@@ -1,7 +1,7 @@
-class FixedFungibleReader
-  FIXED_FUNGIBLE_HANDLER_ADDRESS = '0x3300000000000000000000000000000000000002'
+class Erc20FixedDenominationReader
+  ERC20_FIXED_DENOMINATION_MANAGER_ADDRESS = '0x3300000000000000000000000000000000000002'
 
-  # Token struct returned by FixedFungibleProtocolHandler
+  # Token struct returned by ERC20FixedDenominationManager
   TOKEN_STRUCT = {
     'components' => [
       { 'name' => 'tick', 'type' => 'string' },
@@ -36,7 +36,7 @@ class FixedFungibleReader
 
     # Make the call
     result = EthRpcClient.l2.eth_call(
-      to: FIXED_FUNGIBLE_HANDLER_ADDRESS,
+      to: ERC20_FIXED_DENOMINATION_MANAGER_ADDRESS,
       data: data,
       block_number: block_tag
     )
@@ -59,7 +59,7 @@ class FixedFungibleReader
     {
       tokenContract: token_tuple[0],
       deployTxHash: '0x' + token_tuple[1].unpack1('H*'),
-      protocol: 'fixed-fungible',
+      protocol: 'erc-20-fixed-denomination',
       tick: token_tuple[2],
       maxSupply: token_tuple[3],
       mintLimit: token_tuple[4], # mintAmount field is used as mintLimit
@@ -81,7 +81,7 @@ class FixedFungibleReader
     token[:tokenContract] != '0x0000000000000000000000000000000000000000'
   end
 
-  # Note: FixedFungibleProtocolHandler doesn't track mints by tick+id, it tracks token items by ethscription hash
+  # Note: ERC20FixedDenominationManager doesn't track mints by tick+id, it tracks token items by ethscription hash
   # This method is kept for compatibility but may need redesign
   def self.get_token_item(ethscription_tx_hash, block_tag: 'latest')
     # Encode function call for getTokenItem(bytes32)
@@ -99,7 +99,7 @@ class FixedFungibleReader
 
     # Make the call
     result = EthRpcClient.l2.eth_call(
-      to: FIXED_FUNGIBLE_HANDLER_ADDRESS,
+      to: ERC20_FIXED_DENOMINATION_MANAGER_ADDRESS,
       data: data,
       block_number: block_tag
     )
@@ -124,15 +124,15 @@ class FixedFungibleReader
     nil
   end
 
-  # Legacy compatibility - mints aren't tracked by ID in FixedFungibleProtocolHandler
+  # Legacy compatibility - mints aren't tracked by ID in ERC20FixedDenominationManager
   def self.get_mint(tick, mint_id, block_tag: 'latest')
     # This would need to be reimplemented if mint tracking by ID is needed
-    # For now, return nil as FixedFungibleProtocolHandler doesn't support this
+    # For now, return nil as ERC20FixedDenominationManager doesn't support this
     nil
   end
 
   def self.mint_exists?(tick, mint_id, block_tag: 'latest')
-    # FixedFungibleProtocolHandler doesn't track mints by tick+id
+    # ERC20FixedDenominationManager doesn't track mints by tick+id
     false
   end
 

--- a/lib/protocol_event_reader.rb
+++ b/lib/protocol_event_reader.rb
@@ -8,13 +8,10 @@ class ProtocolEventReader
     'ProtocolHandlerSuccess' => 'ProtocolHandlerSuccess(bytes32,string,bytes)',
     'ProtocolHandlerFailed' => 'ProtocolHandlerFailed(bytes32,string,bytes)',
 
-    # ERC20FixedDenominationManager.sol events (including legacy aliases)
+    # ERC20FixedDenominationManager.sol events
     'ERC20FixedDenominationTokenDeployed' => 'ERC20FixedDenominationTokenDeployed(bytes32,address,string,uint256,uint256)',
     'ERC20FixedDenominationTokenMinted' => 'ERC20FixedDenominationTokenMinted(bytes32,address,uint256,bytes32)',
     'ERC20FixedDenominationTokenTransferred' => 'ERC20FixedDenominationTokenTransferred(bytes32,address,address,uint256,bytes32)',
-    'FixedFungibleTokenDeployed' => 'FixedFungibleTokenDeployed(bytes32,address,string,uint256,uint256)',
-    'FixedFungibleTokenMinted' => 'FixedFungibleTokenMinted(bytes32,address,uint256,bytes32)',
-    'FixedFungibleTokenTransferred' => 'FixedFungibleTokenTransferred(bytes32,address,address,uint256,bytes32)',
 
     # CollectionsManager.sol events
     # CollectionsManager.sol events (match actual signatures)

--- a/lib/protocol_event_reader.rb
+++ b/lib/protocol_event_reader.rb
@@ -8,7 +8,10 @@ class ProtocolEventReader
     'ProtocolHandlerSuccess' => 'ProtocolHandlerSuccess(bytes32,string,bytes)',
     'ProtocolHandlerFailed' => 'ProtocolHandlerFailed(bytes32,string,bytes)',
 
-    # FixedFungibleProtocolHandler.sol events
+    # ERC20FixedDenominationManager.sol events (including legacy aliases)
+    'ERC20FixedDenominationTokenDeployed' => 'ERC20FixedDenominationTokenDeployed(bytes32,address,string,uint256,uint256)',
+    'ERC20FixedDenominationTokenMinted' => 'ERC20FixedDenominationTokenMinted(bytes32,address,uint256,bytes32)',
+    'ERC20FixedDenominationTokenTransferred' => 'ERC20FixedDenominationTokenTransferred(bytes32,address,address,uint256,bytes32)',
     'FixedFungibleTokenDeployed' => 'FixedFungibleTokenDeployed(bytes32,address,string,uint256,uint256)',
     'FixedFungibleTokenMinted' => 'FixedFungibleTokenMinted(bytes32,address,uint256,bytes32)',
     'FixedFungibleTokenTransferred' => 'FixedFungibleTokenTransferred(bytes32,address,address,uint256,bytes32)',
@@ -60,12 +63,12 @@ class ProtocolEventReader
       parse_protocol_handler_success(log)
     when 'ProtocolHandlerFailed'
       parse_protocol_handler_failed(log)
-    when 'FixedFungibleTokenDeployed'
-      parse_fixed_fungible_token_deployed(log)
-    when 'FixedFungibleTokenMinted'
-      parse_fixed_fungible_token_minted(log)
-    when 'FixedFungibleTokenTransferred'
-      parse_fixed_fungible_token_transferred(log)
+    when 'ERC20FixedDenominationTokenDeployed', 'FixedFungibleTokenDeployed'
+      parse_erc20_fixed_denomination_token_deployed(log)
+    when 'ERC20FixedDenominationTokenMinted', 'FixedFungibleTokenMinted'
+      parse_erc20_fixed_denomination_token_minted(log)
+    when 'ERC20FixedDenominationTokenTransferred', 'FixedFungibleTokenTransferred'
+      parse_erc20_fixed_denomination_token_transferred(log)
     when 'CollectionCreated'
       parse_collection_created(log)
     when 'ItemsAdded'
@@ -201,8 +204,8 @@ class ProtocolEventReader
     }
   end
 
-  def self.parse_fixed_fungible_token_deployed(log)
-    # FixedFungibleTokenDeployed(bytes32 indexed deployTxHash, address indexed tokenAddress, string tick, uint256 maxSupply, uint256 mintAmount)
+  def self.parse_erc20_fixed_denomination_token_deployed(log)
+    # ERC20FixedDenominationTokenDeployed(bytes32 indexed deployTxHash, address indexed tokenAddress, string tick, uint256 maxSupply, uint256 mintAmount)
     deploy_tx_hash = log['topics'][1]
     token_address = '0x' + log['topics'][2][-40..] if log['topics'][2]  # Last 20 bytes of topic
 
@@ -210,7 +213,7 @@ class ProtocolEventReader
     decoded = Eth::Abi.decode(['string', 'uint256', 'uint256'], data)
 
     {
-      event: 'FixedFungibleTokenDeployed',
+      event: 'ERC20FixedDenominationTokenDeployed',
       deploy_tx_hash: deploy_tx_hash,
       token_contract: token_address,
       tick: decoded[0],
@@ -218,12 +221,12 @@ class ProtocolEventReader
       mint_amount: decoded[2]
     }
   rescue => e
-    Rails.logger.error "Failed to parse FixedFungibleTokenDeployed: #{e.message}"
+    Rails.logger.error "Failed to parse ERC20FixedDenominationTokenDeployed: #{e.message}"
     nil
   end
 
-  def self.parse_fixed_fungible_token_minted(log)
-    # FixedFungibleTokenMinted(bytes32 indexed deployTxHash, address indexed to, uint256 amount, bytes32 ethscriptionTxHash)
+  def self.parse_erc20_fixed_denomination_token_minted(log)
+    # ERC20FixedDenominationTokenMinted(bytes32 indexed deployTxHash, address indexed to, uint256 amount, bytes32 ethscriptionTxHash)
     deploy_tx_hash = log['topics'][1]
     to_address = '0x' + log['topics'][2][-40..] if log['topics'][2]  # Last 20 bytes
 
@@ -231,19 +234,19 @@ class ProtocolEventReader
     decoded = Eth::Abi.decode(['uint256', 'bytes32'], data)
 
     {
-      event: 'FixedFungibleTokenMinted',
+      event: 'ERC20FixedDenominationTokenMinted',
       deploy_tx_hash: deploy_tx_hash,
       to: to_address,
       amount: decoded[0],
       ethscription_tx_hash: '0x' + decoded[1].unpack1('H*')
     }
   rescue => e
-    Rails.logger.error "Failed to parse FixedFungibleTokenMinted: #{e.message}"
+    Rails.logger.error "Failed to parse ERC20FixedDenominationTokenMinted: #{e.message}"
     nil
   end
 
-  def self.parse_fixed_fungible_token_transferred(log)
-    # FixedFungibleTokenTransferred(bytes32 indexed deployTxHash, address indexed from, address indexed to, uint256 amount, bytes32 ethscriptionTxHash)
+  def self.parse_erc20_fixed_denomination_token_transferred(log)
+    # ERC20FixedDenominationTokenTransferred(bytes32 indexed deployTxHash, address indexed from, address indexed to, uint256 amount, bytes32 ethscriptionTxHash)
     deploy_tx_hash = log['topics'][1]
     from_address = '0x' + log['topics'][2][-40..] if log['topics'][2]  # Last 20 bytes
     to_address = '0x' + log['topics'][3][-40..] if log['topics'][3]
@@ -252,7 +255,7 @@ class ProtocolEventReader
     decoded = Eth::Abi.decode(['uint256', 'bytes32'], data)
 
     {
-      event: 'FixedFungibleTokenTransferred',
+      event: 'ERC20FixedDenominationTokenTransferred',
       deploy_tx_hash: deploy_tx_hash,
       from: from_address,
       to: to_address,
@@ -260,7 +263,7 @@ class ProtocolEventReader
       ethscription_tx_hash: '0x' + decoded[1].unpack1('H*')
     }
   rescue => e
-    Rails.logger.error "Failed to parse FixedFungibleTokenTransferred: #{e.message}"
+    Rails.logger.error "Failed to parse ERC20FixedDenominationTokenTransferred: #{e.message}"
     nil
   end
 

--- a/lib/sys_config.rb
+++ b/lib/sys_config.rb
@@ -9,7 +9,6 @@ module SysConfig
   SYSTEM_ADDRESS = Address20.from_hex("0xdeaddeaddeaddeaddeaddeaddeaddeaddead0001")
   L1_INFO_ADDRESS = Address20.from_hex("0x4200000000000000000000000000000000000015")
   ETHSCRIPTIONS_ADDRESS = Address20.from_hex("0x3300000000000000000000000000000000000001")
-  FIXED_FUNGIBLE_HANDLER_ADDRESS = Address20.from_hex("0x3300000000000000000000000000000000000002")
   
   # Deposit transaction domains
   USER_DEPOSIT_SOURCE_DOMAIN = 0
@@ -19,9 +18,6 @@ module SysConfig
     ETHSCRIPTIONS_ADDRESS
   end
   
-  def fixed_fungible_handler_contract_address
-    FIXED_FUNGIBLE_HANDLER_ADDRESS
-  end
   
   def block_gas_limit(block = nil)
     L2_BLOCK_GAS_LIMIT

--- a/spec/integration/collections_protocol_e2e_spec.rb
+++ b/spec/integration/collections_protocol_e2e_spec.rb
@@ -80,7 +80,7 @@ RSpec.describe "Collections Protocol End-to-End", type: :integration do
     it "creates collection and validates protocol execution" do
       # Use the simple, working pattern
       collection_data = {
-        "p" => "collections",
+        "p" => "erc-721-ethscriptions-collection",
         "op" => "create_collection",
         "name" => "Test NFT",
         "symbol" => "TNFT",
@@ -116,7 +116,7 @@ RSpec.describe "Collections Protocol End-to-End", type: :integration do
       # The content might be in binary format
       content_str = stored[:content].is_a?(String) ? stored[:content] : stored[:content].force_encoding('UTF-8')
 
-      expect(content_str).to include('"p":"collections"')
+      expect(content_str).to include('"p":"erc-721-ethscriptions-collection"')
       expect(content_str).to include('"op":"create_collection"')
       expect(content_str).to include('"name":"Test NFT"')
 
@@ -160,7 +160,7 @@ RSpec.describe "Collections Protocol End-to-End", type: :integration do
     it "adds multiple items with attributes and validates execution" do
       # Use the same pattern as the first test which works
       collection_data = {
-        "p" => "collections",
+        "p" => "erc-721-ethscriptions-collection",
         "op" => "create_collection",
         "name" => "Test Batch Collection",
         "symbol" => "TBATCH",
@@ -215,7 +215,7 @@ RSpec.describe "Collections Protocol End-to-End", type: :integration do
 
       # Complex nested structure matching real-world usage
       batch_data = {
-        "p" => "collections",
+        "p" => "erc-721-ethscriptions-collection",
         "op" => "add_items_batch",
         "collection_id" => collection_id,
         "items" => [

--- a/spec/integration/collections_protocol_spec.rb
+++ b/spec/integration/collections_protocol_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe "Collections Protocol", type: :integration do
   describe "Collection Creation" do
     it "creates a collection with metadata fields" do
       collection_data = {
-        "p" => "collections",
+        "p" => "erc-721-ethscriptions-collection",
         "op" => "create_collection",
         "name" => "Test NFTs",
         "symbol" => "TEST",
@@ -34,7 +34,7 @@ RSpec.describe "Collections Protocol", type: :integration do
         stored = get_ethscription_content(ethscription_id)
 
         # Verify the content includes our data
-        expect(stored[:content]).to include('"p":"collections"')
+        expect(stored[:content]).to include('"p":"erc-721-ethscriptions-collection"')
         expect(stored[:content]).to include('"op":"create_collection"')
         expect(stored[:content]).to include('"name":"Test NFTs"')
 
@@ -44,7 +44,7 @@ RSpec.describe "Collections Protocol", type: :integration do
 
     it "creates a minimal collection with only required fields" do
       collection_data = {
-        "p" => "collections",
+        "p" => "erc-721-ethscriptions-collection",
         "op" => "create_collection",
         "name" => "Minimal Collection",
         "symbol" => "MIN",
@@ -62,7 +62,7 @@ RSpec.describe "Collections Protocol", type: :integration do
 
     it "handles numeric strings for total_supply (JS compatibility)" do
       collection_data = {
-        "p" => "collections",
+        "p" => "erc-721-ethscriptions-collection",
         "op" => "create_collection",
         "name" => "Big Supply Collection",
         "symbol" => "BIG",
@@ -84,7 +84,7 @@ RSpec.describe "Collections Protocol", type: :integration do
 
     it "creates an item with NFT attributes" do
       item_data = {
-        "p" => "collections",
+        "p" => "erc-721-ethscriptions-collection",
         "op" => "create_item",
         "collection_id" => collection_id,
         "name" => "Item #1",
@@ -108,7 +108,7 @@ RSpec.describe "Collections Protocol", type: :integration do
 
     it "creates an item with camelCase attribute keys" do
       item_data = {
-        "p" => "collections",
+        "p" => "erc-721-ethscriptions-collection",
         "op" => "create_item",
         "collection_id" => collection_id,
         "name" => "Item #2",
@@ -130,7 +130,7 @@ RSpec.describe "Collections Protocol", type: :integration do
     it "edits an item to clear attributes using type hint" do
       # Clear attributes by providing empty array with type hint
       edit_data = {
-        "p" => "collections",
+        "p" => "erc-721-ethscriptions-collection",
         "op" => "edit_item",
         "collection_id" => collection_id,
         "item_index" =>0,
@@ -149,7 +149,7 @@ RSpec.describe "Collections Protocol", type: :integration do
 
     it "edits an item to update attributes" do
       edit_data = {
-        "p" => "collections",
+        "p" => "erc-721-ethscriptions-collection",
         "op" => "edit_item",
         "collection_id" => collection_id,
         "item_index" =>0,
@@ -174,7 +174,7 @@ RSpec.describe "Collections Protocol", type: :integration do
 
     it "locks a collection" do
       lock_data = {
-        "p" => "collections",
+        "p" => "erc-721-ethscriptions-collection",
         "op" => "lock_collection",
         "collection_id" => collection_id
       }
@@ -190,7 +190,7 @@ RSpec.describe "Collections Protocol", type: :integration do
 
     it "transfers collection ownership" do
       transfer_data = {
-        "p" => "collections",
+        "p" => "erc-721-ethscriptions-collection",
         "op" => "transfer_ownership",
         "collection_id" => collection_id,
         "new_owner" => bob
@@ -207,7 +207,7 @@ RSpec.describe "Collections Protocol", type: :integration do
 
     it "handles batch operations with arrays" do
       batch_data = {
-        "p" => "collections",
+        "p" => "erc-721-ethscriptions-collection",
         "op" => "batch_create_items",
         "collection_id" => collection_id,
         "items" => [
@@ -239,7 +239,7 @@ RSpec.describe "Collections Protocol", type: :integration do
   describe "Type Inference" do
     it "correctly infers mixed field types" do
       mixed_data = {
-        "p" => "collections",
+        "p" => "erc-721-ethscriptions-collection",
         "op" => "complex_operation",
         "item_id" => "12345", # String number -> uint256
         "active" => true, # JSON boolean -> bool
@@ -262,7 +262,7 @@ RSpec.describe "Collections Protocol", type: :integration do
     it "preserves JSON field order for struct compatibility" do
       # Fields must be in exact order to match Solidity struct
       struct_data = {
-        "p" => "collections",
+        "p" => "erc-721-ethscriptions-collection",
         "op" => "structured_op",
         "field1" => "first",
         "field2" => "second",
@@ -286,7 +286,7 @@ RSpec.describe "Collections Protocol", type: :integration do
     it "creates a collection and verifies it exists in contract" do
       # Must include ALL CollectionMetadata fields in correct order
       collection_data = {
-        "p" => "collections",
+        "p" => "erc-721-ethscriptions-collection",
         "op" => "create_collection",
         "name" => "Verified Collection",
         "symbol" => "VRFY",
@@ -337,7 +337,7 @@ RSpec.describe "Collections Protocol", type: :integration do
       # Send data with number too large for uint256
       too_big = "115792089237316195423570985008687907853269984665640564039457584007913129639936"
       invalid_data = {
-        "p" => "collections",
+        "p" => "erc-721-ethscriptions-collection",
         "op" => "create_collection",
         "name" => "Invalid",
         "total_supply" => too_big
@@ -351,7 +351,7 @@ RSpec.describe "Collections Protocol", type: :integration do
         )
       ) do |results, stored|
         # Ethscription created and content stored
-        expect(stored[:content]).to include('"p":"collections"')
+        expect(stored[:content]).to include('"p":"erc-721-ethscriptions-collection"')
 
         # TODO: Verify collection count didn't increase
         # final_collection_count = get_total_collections()
@@ -378,7 +378,7 @@ RSpec.describe "Collections Protocol", type: :integration do
     it "creates collection, adds items, edits items, and locks collection" do
       # Step 1: Create collection
       create_data = {
-        "p" => "collections",
+        "p" => "erc-721-ethscriptions-collection",
         "op" => "create_collection",
         "name" => "Full Test Collection",
         "symbol" => "FULL",
@@ -402,7 +402,7 @@ RSpec.describe "Collections Protocol", type: :integration do
 
       # Step 2: Add an item
       item_data = {
-        "p" => "collections",
+        "p" => "erc-721-ethscriptions-collection",
         "op" => "create_item",
         "collection_id" => collection_id,
         "name" => "Item 1",
@@ -428,7 +428,7 @@ RSpec.describe "Collections Protocol", type: :integration do
 
       # Step 3: Edit item to clear attributes
       edit_data = {
-        "p" => "collections",
+        "p" => "erc-721-ethscriptions-collection",
         "op" => "edit_item",
         "collection_id" => collection_id,
         "item_index" =>0,
@@ -451,7 +451,7 @@ RSpec.describe "Collections Protocol", type: :integration do
 
       # Step 4: Lock collection
       lock_data = {
-        "p" => "collections",
+        "p" => "erc-721-ethscriptions-collection",
         "op" => "lock_collection",
         "collection_id" => collection_id
       }
@@ -475,7 +475,7 @@ RSpec.describe "Collections Protocol", type: :integration do
       # ProtocolExtractor now parses JSON instead of using regex
       # so multi-line JSON should work
       multiline_json = {
-        "p" => "collections",
+        "p" => "erc-721-ethscriptions-collection",
         "op" => "create_collection",
         "name" => "Multi-line Test",
         "description" => "This JSON
@@ -496,7 +496,7 @@ lines for readability"
   describe "Boolean String Handling" do
     it "treats string 'true' and 'false' as strings, not booleans" do
       string_bool_data = {
-        "p" => "collections",
+        "p" => "erc-721-ethscriptions-collection",
         "op" => "test_bools",
         "stringTrue" => "true", # Should remain string
         "stringFalse" => "false", # Should remain string

--- a/spec/integration/simple_test_spec.rb
+++ b/spec/integration/simple_test_spec.rb
@@ -52,7 +52,7 @@ RSpec.describe "Simple Ethscription Creation", type: :integration do
   it "tests content size limits" do
     # Test with increasing content sizes
     base_data = {
-      "p" => "collections",
+      "p" => "erc-721-ethscriptions-collection",
       "op" => "create_collection",
       "name" => "Test",
       "symbol" => "TST",
@@ -78,7 +78,7 @@ RSpec.describe "Simple Ethscription Creation", type: :integration do
 
     puts "Original content length: #{base_data.to_json.length}"
     puts "Stored content length: #{stored[:content].length}"
-    puts "Content starts with 'p': #{stored[:content].start_with?('{"p":"collections"')}"
+    puts "Content starts with 'p': #{stored[:content].start_with?('{"p":"erc-721-ethscriptions-collection"')}"
     puts "First 50 chars: #{stored[:content][0..49]}"
 
     # For debugging, show if content was truncated
@@ -93,7 +93,7 @@ RSpec.describe "Simple Ethscription Creation", type: :integration do
   it "creates a simple collections protocol ethscription" do
     # Try the simplest collections protocol data
     collection_data = {
-      "p" => "collections",
+      "p" => "erc-721-ethscriptions-collection",
       "op" => "create_collection",
       "name" => "Test",
       "symbol" => "TST",
@@ -119,11 +119,11 @@ RSpec.describe "Simple Ethscription Creation", type: :integration do
     puts "Collections test results:"
     puts "Ethscription ID: #{ethscription_id}"
     puts "Stored content: #{stored[:content].inspect}"
-    puts "Content includes 'p': #{stored[:content].include?('"p":"collections"')}"
+    puts "Content includes 'p': #{stored[:content].include?('"p":"erc-721-ethscriptions-collection"')}"
     puts "Full match: #{stored[:content] == collection_data.to_json}"
 
     expect(results[:ethscription_ids]).not_to be_empty, "Should create ethscription ID"
     expect(results[:l2_receipts]).not_to be_empty, "Should have L2 receipt"
-    expect(stored[:content]).to include('"p":"collections"'), "Content should include protocol"
+    expect(stored[:content]).to include('"p":"erc-721-ethscriptions-collection"'), "Content should include protocol"
   end
 end

--- a/spec/integration/token_protocol_e2e_spec.rb
+++ b/spec/integration/token_protocol_e2e_spec.rb
@@ -10,7 +10,8 @@ RSpec.describe "Token Protocol End-to-End", type: :integration do
 
   describe "Complete Token Workflow with Protocol Validation" do
     it "deploys token and validates protocol execution" do
-      # JSON must be in exact format for token protocol
+      # Note: 'erc-20' is a legacy protocol identifier; the canonical protocol name is now 'erc-20-fixed-denomination'.
+      # This test uses the legacy format, which is normalized to the canonical name by the system.
       deploy_json = '{"p":"erc-20","op":"deploy","tick":"testcoin","max":"1000000","lim":"1000"}'
 
       result = create_and_validate_ethscription(

--- a/spec/integration/tokens_protocol_spec.rb
+++ b/spec/integration/tokens_protocol_spec.rb
@@ -308,8 +308,8 @@ RSpec.describe "Tokens Protocol", type: :integration do
         # The token regex requires exact format with no extra spaces
         expect(stored[:content]).to include('erc-20')
 
-        token_params = FixedFungibleTokenParamsExtractor.extract(content_uri)
-        expect(token_params).to eq(FixedFungibleTokenParamsExtractor::DEFAULT_PARAMS)
+        token_params = Erc20FixedDenominationParser.extract(content_uri)
+        expect(token_params).to eq(Erc20FixedDenominationParser::DEFAULT_PARAMS)
       end
     end
 
@@ -418,7 +418,7 @@ RSpec.describe "Tokens Protocol", type: :integration do
         expect(token_state[:totalMinted]).to eq(0)
         expect(token_state[:ethscriptionId].downcase).to eq(ethscription_id.downcase)
         expect(token_state[:tokenContract]).to match(/^0x[0-9a-fA-F]{40}$/)
-        expect(token_state[:protocol]).to eq('fixed-fungible')
+        expect(token_state[:protocol]).to eq('erc-20-fixed-denomination')
       end
     end
 
@@ -589,7 +589,7 @@ RSpec.describe "Tokens Protocol", type: :integration do
   private
 
   def get_token_state(tick)
-    token = FixedFungibleReader.get_token(tick)
+    token = Erc20FixedDenominationReader.get_token(tick)
     return nil if token.nil?
 
     zero_address = '0x0000000000000000000000000000000000000000'
@@ -607,15 +607,15 @@ RSpec.describe "Tokens Protocol", type: :integration do
   end
 
   def token_exists?(tick)
-    FixedFungibleReader.token_exists?(tick)
+    Erc20FixedDenominationReader.token_exists?(tick)
   end
 
   def get_token_balance(tick, address)
-    FixedFungibleReader.get_token_balance(tick, address)
+    Erc20FixedDenominationReader.get_token_balance(tick, address)
   end
 
   def get_mint_item(ethscription_id)
-    item = FixedFungibleReader.get_token_item(ethscription_id)
+    item = Erc20FixedDenominationReader.get_token_item(ethscription_id)
 
     zero_bytes32 = '0x0000000000000000000000000000000000000000000000000000000000000000'
 

--- a/spec/models/erc20_fixed_denomination_parser_spec.rb
+++ b/spec/models/erc20_fixed_denomination_parser_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe FixedFungibleTokenParamsExtractor do
+RSpec.describe Erc20FixedDenominationParser do
   let(:default_params) { [''.b, ''.b, ''.b, 0, 0, 0] }
   let(:uint256_max) { 2**256 - 1 }
 
@@ -8,292 +8,292 @@ RSpec.describe FixedFungibleTokenParamsExtractor do
     context 'valid operations' do
       it 'extracts deploy operation params with all required fields' do
         content_uri = 'data:,{"p":"erc-20","op":"deploy","tick":"punk","max":"21000000","lim":"1000"}'
-        expect(FixedFungibleTokenParamsExtractor.extract(content_uri)).to eq(['deploy'.b, 'fixed-fungible'.b, 'punk'.b, 21000000, 1000, 0])
+        expect(Erc20FixedDenominationParser.extract(content_uri)).to eq(['deploy'.b, 'erc-20-fixed-denomination'.b, 'punk'.b, 21000000, 1000, 0])
       end
 
       it 'extracts mint operation params with all required fields' do
         content_uri = 'data:,{"p":"erc-20","op":"mint","tick":"punk","id":"1","amt":"100"}'
-        expect(FixedFungibleTokenParamsExtractor.extract(content_uri)).to eq(['mint'.b, 'fixed-fungible'.b, 'punk'.b, 1, 0, 100])
+        expect(Erc20FixedDenominationParser.extract(content_uri)).to eq(['mint'.b, 'erc-20-fixed-denomination'.b, 'punk'.b, 1, 0, 100])
       end
 
       it 'handles zero values correctly' do
         content_uri = 'data:,{"p":"erc-20","op":"mint","tick":"punk","id":"0","amt":"0"}'
-        expect(FixedFungibleTokenParamsExtractor.extract(content_uri)).to eq(['mint'.b, 'fixed-fungible'.b, 'punk'.b, 0, 0, 0])
+        expect(Erc20FixedDenominationParser.extract(content_uri)).to eq(['mint'.b, 'erc-20-fixed-denomination'.b, 'punk'.b, 0, 0, 0])
       end
 
       it 'handles single character tick' do
         content_uri = 'data:,{"p":"erc-20","op":"mint","tick":"a","id":"1","amt":"100"}'
-        expect(FixedFungibleTokenParamsExtractor.extract(content_uri)).to eq(['mint'.b, 'fixed-fungible'.b, 'a'.b, 1, 0, 100])
+        expect(Erc20FixedDenominationParser.extract(content_uri)).to eq(['mint'.b, 'erc-20-fixed-denomination'.b, 'a'.b, 1, 0, 100])
       end
 
       it 'handles max length tick (28 chars)' do
         content_uri = 'data:,{"p":"erc-20","op":"mint","tick":"abcdefghijklmnopqrstuvwxyz12","id":"1","amt":"100"}'
-        expect(FixedFungibleTokenParamsExtractor.extract(content_uri)).to eq(['mint'.b, 'fixed-fungible'.b, 'abcdefghijklmnopqrstuvwxyz12'.b, 1, 0, 100])
+        expect(Erc20FixedDenominationParser.extract(content_uri)).to eq(['mint'.b, 'erc-20-fixed-denomination'.b, 'abcdefghijklmnopqrstuvwxyz12'.b, 1, 0, 100])
       end
 
       it 'handles exactly max uint256 value' do
         content_uri = "data:,{\"p\":\"erc-20\",\"op\":\"mint\",\"tick\":\"punk\",\"id\":\"1\",\"amt\":\"#{uint256_max}\"}"
-        expect(FixedFungibleTokenParamsExtractor.extract(content_uri)).to eq(['mint'.b, 'fixed-fungible'.b, 'punk'.b, 1, 0, uint256_max])
+        expect(Erc20FixedDenominationParser.extract(content_uri)).to eq(['mint'.b, 'erc-20-fixed-denomination'.b, 'punk'.b, 1, 0, uint256_max])
       end
 
       it 'handles deploy with zero lim' do
         content_uri = 'data:,{"p":"erc-20","op":"deploy","tick":"test","max":"1000","lim":"0"}'
-        expect(FixedFungibleTokenParamsExtractor.extract(content_uri)).to eq(['deploy'.b, 'fixed-fungible'.b, 'test'.b, 1000, 0, 0])
+        expect(Erc20FixedDenominationParser.extract(content_uri)).to eq(['deploy'.b, 'erc-20-fixed-denomination'.b, 'test'.b, 1000, 0, 0])
       end
     end
 
     context 'strict format requirements' do
       it 'rejects mint with integer values instead of strings' do
         content_uri = 'data:,{"p":"erc-20","op":"mint","tick":"punk","id":1,"amt":100}'
-        expect(FixedFungibleTokenParamsExtractor.extract(content_uri)).to eq(default_params)
+        expect(Erc20FixedDenominationParser.extract(content_uri)).to eq(default_params)
       end
 
       it 'rejects mint with optional fields omitted (id missing)' do
         content_uri = 'data:,{"p":"erc-20","op":"mint","tick":"punk","amt":"100"}'
-        expect(FixedFungibleTokenParamsExtractor.extract(content_uri)).to eq(default_params)
+        expect(Erc20FixedDenominationParser.extract(content_uri)).to eq(default_params)
       end
 
       it 'rejects mint with optional fields omitted (amt missing)' do
         content_uri = 'data:,{"p":"erc-20","op":"mint","tick":"punk","id":"1"}'
-        expect(FixedFungibleTokenParamsExtractor.extract(content_uri)).to eq(default_params)
+        expect(Erc20FixedDenominationParser.extract(content_uri)).to eq(default_params)
       end
 
       it 'rejects mint with only required protocol fields' do
         content_uri = 'data:,{"p":"erc-20","op":"mint","tick":"punk"}'
-        expect(FixedFungibleTokenParamsExtractor.extract(content_uri)).to eq(default_params)
+        expect(Erc20FixedDenominationParser.extract(content_uri)).to eq(default_params)
       end
 
       it 'rejects extra spaces in JSON' do
         content_uri = 'data:,{"p": "erc-20","op": "mint","tick": "punk","id": "1","amt": "100"}'
-        expect(FixedFungibleTokenParamsExtractor.extract(content_uri)).to eq(default_params)
+        expect(Erc20FixedDenominationParser.extract(content_uri)).to eq(default_params)
       end
 
       it 'rejects wrong key order' do
         content_uri = 'data:,{"op":"mint","p":"erc-20","tick":"punk","id":"1","amt":"100"}'
-        expect(FixedFungibleTokenParamsExtractor.extract(content_uri)).to eq(default_params)
+        expect(Erc20FixedDenominationParser.extract(content_uri)).to eq(default_params)
       end
 
       it 'rejects extra fields' do
         content_uri = 'data:,{"p":"erc-20","op":"mint","tick":"punk","id":"1","amt":"100","extra":"bad"}'
-        expect(FixedFungibleTokenParamsExtractor.extract(content_uri)).to eq(default_params)
+        expect(Erc20FixedDenominationParser.extract(content_uri)).to eq(default_params)
       end
     end
 
     context 'security and data smuggling prevention' do
       it 'rejects array in id field (security issue)' do
         content_uri = 'data:,{"p":"erc-20","op":"mint","tick":"punk","id":[831,832],"amt":"1"}'
-        expect(FixedFungibleTokenParamsExtractor.extract(content_uri)).to eq(default_params)
+        expect(Erc20FixedDenominationParser.extract(content_uri)).to eq(default_params)
       end
 
       it 'rejects object in amt field' do
         content_uri = 'data:,{"p":"erc-20","op":"mint","tick":"punk","id":"1","amt":{"value":100}}'
-        expect(FixedFungibleTokenParamsExtractor.extract(content_uri)).to eq(default_params)
+        expect(Erc20FixedDenominationParser.extract(content_uri)).to eq(default_params)
       end
 
       it 'rejects SQL injection in tick' do
         content_uri = 'data:,{"p":"erc-20","op":"mint","tick":"punk\nDROP TABLE"}'
-        expect(FixedFungibleTokenParamsExtractor.extract(content_uri)).to eq(default_params)
+        expect(Erc20FixedDenominationParser.extract(content_uri)).to eq(default_params)
       end
 
       it 'rejects nested JSON objects' do
         content_uri = 'data:,{"p":"erc-20","op":"mint","tick":"punk","id":"1","amt":"100","meta":{"foo":"bar"}}'
-        expect(FixedFungibleTokenParamsExtractor.extract(content_uri)).to eq(default_params)
+        expect(Erc20FixedDenominationParser.extract(content_uri)).to eq(default_params)
       end
     end
 
     context 'data type validation' do
       it 'rejects boolean in max field' do
         content_uri = 'data:,{"p":"erc-20","op":"deploy","tick":"punk","max":true,"lim":"100"}'
-        expect(FixedFungibleTokenParamsExtractor.extract(content_uri)).to eq(default_params)
+        expect(Erc20FixedDenominationParser.extract(content_uri)).to eq(default_params)
       end
 
       it 'rejects null values in deploy' do
         content_uri = 'data:,{"p":"erc-20","op":"deploy","tick":"punk","max":null,"lim":"100"}'
-        expect(FixedFungibleTokenParamsExtractor.extract(content_uri)).to eq(default_params)
+        expect(Erc20FixedDenominationParser.extract(content_uri)).to eq(default_params)
       end
 
       it 'rejects array as op' do
         content_uri = 'data:,{"p":"erc-20","op":["deploy"],"tick":"punk","max":"1000","lim":"100"}'
-        expect(FixedFungibleTokenParamsExtractor.extract(content_uri)).to eq(default_params)
+        expect(Erc20FixedDenominationParser.extract(content_uri)).to eq(default_params)
       end
 
       it 'rejects non-JSON object (array)' do
         content_uri = 'data:,["not","an","object"]'
-        expect(FixedFungibleTokenParamsExtractor.extract(content_uri)).to eq(default_params)
+        expect(Erc20FixedDenominationParser.extract(content_uri)).to eq(default_params)
       end
     end
 
     context 'number format validation' do
       it 'rejects non-numeric string' do
         content_uri = 'data:,{"p":"erc-20","op":"mint","tick":"punk","id":"abc","amt":"100"}'
-        expect(FixedFungibleTokenParamsExtractor.extract(content_uri)).to eq(default_params)
+        expect(Erc20FixedDenominationParser.extract(content_uri)).to eq(default_params)
       end
 
       it 'rejects negative number' do
         content_uri = 'data:,{"p":"erc-20","op":"mint","tick":"punk","id":"-1","amt":"100"}'
-        expect(FixedFungibleTokenParamsExtractor.extract(content_uri)).to eq(default_params)
+        expect(Erc20FixedDenominationParser.extract(content_uri)).to eq(default_params)
       end
 
       it 'rejects hex number' do
         content_uri = 'data:,{"p":"erc-20","op":"mint","tick":"punk","id":"0x10","amt":"100"}'
-        expect(FixedFungibleTokenParamsExtractor.extract(content_uri)).to eq(default_params)
+        expect(Erc20FixedDenominationParser.extract(content_uri)).to eq(default_params)
       end
 
       it 'rejects float number' do
         content_uri = 'data:,{"p":"erc-20","op":"mint","tick":"punk","id":"1.5","amt":"100"}'
-        expect(FixedFungibleTokenParamsExtractor.extract(content_uri)).to eq(default_params)
+        expect(Erc20FixedDenominationParser.extract(content_uri)).to eq(default_params)
       end
 
       it 'rejects number with whitespace' do
         content_uri = 'data:,{"p":"erc-20","op":"mint","tick":"punk","id":" 1 ","amt":"100"}'
-        expect(FixedFungibleTokenParamsExtractor.extract(content_uri)).to eq(default_params)
+        expect(Erc20FixedDenominationParser.extract(content_uri)).to eq(default_params)
       end
 
       it 'rejects leading zeros (except standalone zero)' do
         content_uri = 'data:,{"p":"erc-20","op":"mint","tick":"punk","id":"01","amt":"100"}'
-        expect(FixedFungibleTokenParamsExtractor.extract(content_uri)).to eq(default_params)
+        expect(Erc20FixedDenominationParser.extract(content_uri)).to eq(default_params)
       end
 
       it 'rejects number too large for uint256' do
         content_uri = "data:,{\"p\":\"erc-20\",\"op\":\"mint\",\"tick\":\"punk\",\"id\":\"1\",\"amt\":\"#{uint256_max + 1}\"}"
-        expect(FixedFungibleTokenParamsExtractor.extract(content_uri)).to eq(default_params)
+        expect(Erc20FixedDenominationParser.extract(content_uri)).to eq(default_params)
       end
     end
 
     context 'tick validation' do
       it 'rejects tick with uppercase' do
         content_uri = 'data:,{"p":"erc-20","op":"mint","tick":"PUNK","id":"1","amt":"100"}'
-        expect(FixedFungibleTokenParamsExtractor.extract(content_uri)).to eq(default_params)
+        expect(Erc20FixedDenominationParser.extract(content_uri)).to eq(default_params)
       end
 
       it 'rejects tick with special characters (hyphen)' do
         content_uri = 'data:,{"p":"erc-20","op":"mint","tick":"pu-nk","id":"1","amt":"100"}'
-        expect(FixedFungibleTokenParamsExtractor.extract(content_uri)).to eq(default_params)
+        expect(Erc20FixedDenominationParser.extract(content_uri)).to eq(default_params)
       end
 
       it 'rejects tick too long (29 chars)' do
         content_uri = 'data:,{"p":"erc-20","op":"mint","tick":"abcdefghijklmnopqrstuvwxyz123","id":"1","amt":"100"}'
-        expect(FixedFungibleTokenParamsExtractor.extract(content_uri)).to eq(default_params)
+        expect(Erc20FixedDenominationParser.extract(content_uri)).to eq(default_params)
       end
 
       it 'rejects tick with emoji' do
         content_uri = 'data:,{"p":"erc-20","op":"mint","tick":"🚀moon","id":"1","amt":"100"}'
-        expect(FixedFungibleTokenParamsExtractor.extract(content_uri)).to eq(default_params)
+        expect(Erc20FixedDenominationParser.extract(content_uri)).to eq(default_params)
       end
 
       it 'rejects empty string tick' do
         content_uri = 'data:,{"p":"erc-20","op":"mint","tick":"","id":"1","amt":"100"}'
-        expect(FixedFungibleTokenParamsExtractor.extract(content_uri)).to eq(default_params)
+        expect(Erc20FixedDenominationParser.extract(content_uri)).to eq(default_params)
       end
     end
 
     context 'protocol and operation validation' do
       it 'rejects wrong protocol (erc-721)' do
         content_uri = 'data:,{"p":"erc-721","op":"mint","tick":"punk","id":"1","amt":"100"}'
-        expect(FixedFungibleTokenParamsExtractor.extract(content_uri)).to eq(default_params)
+        expect(Erc20FixedDenominationParser.extract(content_uri)).to eq(default_params)
       end
 
       it 'rejects protocol with underscore' do
         content_uri = 'data:,{"p":"erc_20","op":"mint","tick":"punk","id":"1","amt":"100"}'
-        expect(FixedFungibleTokenParamsExtractor.extract(content_uri)).to eq(default_params)
+        expect(Erc20FixedDenominationParser.extract(content_uri)).to eq(default_params)
       end
 
       it 'rejects protocol with uppercase' do
         content_uri = 'data:,{"p":"ERC-20","op":"mint","tick":"punk","id":"1","amt":"100"}'
-        expect(FixedFungibleTokenParamsExtractor.extract(content_uri)).to eq(default_params)
+        expect(Erc20FixedDenominationParser.extract(content_uri)).to eq(default_params)
       end
 
       it 'rejects unknown operations' do
         content_uri = 'data:,{"p":"erc-20","op":"transfer","tick":"punk","id":"1","amt":"100"}'
-        expect(FixedFungibleTokenParamsExtractor.extract(content_uri)).to eq(default_params)
+        expect(Erc20FixedDenominationParser.extract(content_uri)).to eq(default_params)
       end
 
       it 'handles unknown operations with protocol/tick' do
         content_uri = 'data:,{"p":"new-proto","op":"custom","tick":"test"}'
-        expect(FixedFungibleTokenParamsExtractor.extract(content_uri)).to eq(default_params)
+        expect(Erc20FixedDenominationParser.extract(content_uri)).to eq(default_params)
       end
     end
 
     context 'required fields validation' do
       it 'rejects missing op field' do
         content_uri = 'data:,{"p":"erc-20","tick":"punk","max":"1000","lim":"100"}'
-        expect(FixedFungibleTokenParamsExtractor.extract(content_uri)).to eq(default_params)
+        expect(Erc20FixedDenominationParser.extract(content_uri)).to eq(default_params)
       end
 
       it 'rejects missing protocol field' do
         content_uri = 'data:,{"op":"mint","tick":"punk","id":"1","amt":"100"}'
-        expect(FixedFungibleTokenParamsExtractor.extract(content_uri)).to eq(default_params)
+        expect(Erc20FixedDenominationParser.extract(content_uri)).to eq(default_params)
       end
 
       it 'rejects missing tick field' do
         content_uri = 'data:,{"p":"erc-20","op":"mint","id":"1","amt":"100"}'
-        expect(FixedFungibleTokenParamsExtractor.extract(content_uri)).to eq(default_params)
+        expect(Erc20FixedDenominationParser.extract(content_uri)).to eq(default_params)
       end
 
       it 'rejects deploy missing max' do
         content_uri = 'data:,{"p":"erc-20","op":"deploy","tick":"punk","lim":"100"}'
-        expect(FixedFungibleTokenParamsExtractor.extract(content_uri)).to eq(default_params)
+        expect(Erc20FixedDenominationParser.extract(content_uri)).to eq(default_params)
       end
 
       it 'rejects deploy missing lim' do
         content_uri = 'data:,{"p":"erc-20","op":"deploy","tick":"punk","max":"1000"}'
-        expect(FixedFungibleTokenParamsExtractor.extract(content_uri)).to eq(default_params)
+        expect(Erc20FixedDenominationParser.extract(content_uri)).to eq(default_params)
       end
     end
 
     context 'JSON format validation' do
       it 'rejects invalid JSON' do
         content_uri = 'data:,{broken json'
-        expect(FixedFungibleTokenParamsExtractor.extract(content_uri)).to eq(default_params)
+        expect(Erc20FixedDenominationParser.extract(content_uri)).to eq(default_params)
       end
 
       it 'rejects JSON with incorrect format' do
         content_uri = 'data:,{"invalid":true}'
-        expect(FixedFungibleTokenParamsExtractor.extract(content_uri)).to eq(default_params)
+        expect(Erc20FixedDenominationParser.extract(content_uri)).to eq(default_params)
       end
     end
 
     context 'edge cases' do
       it 'returns default params for empty data URI' do
         content_uri = 'data:,{}'
-        expect(FixedFungibleTokenParamsExtractor.extract(content_uri)).to eq(default_params)
+        expect(Erc20FixedDenominationParser.extract(content_uri)).to eq(default_params)
       end
 
       it 'returns default params for non-data URI' do
         content_uri = 'https://example.com'
-        expect(FixedFungibleTokenParamsExtractor.extract(content_uri)).to eq(default_params)
+        expect(Erc20FixedDenominationParser.extract(content_uri)).to eq(default_params)
       end
 
       it 'returns default params for nil input' do
-        expect(FixedFungibleTokenParamsExtractor.extract(nil)).to eq(default_params)
+        expect(Erc20FixedDenominationParser.extract(nil)).to eq(default_params)
       end
 
       it 'returns default params for non-token content' do
         content_uri = 'data:,Hello World!'
-        expect(FixedFungibleTokenParamsExtractor.extract(content_uri)).to eq(default_params)
+        expect(Erc20FixedDenominationParser.extract(content_uri)).to eq(default_params)
       end
 
       it 'returns default params for plain text data' do
         content_uri = 'data:text/plain,Hello'
-        expect(FixedFungibleTokenParamsExtractor.extract(content_uri)).to eq(default_params)
+        expect(Erc20FixedDenominationParser.extract(content_uri)).to eq(default_params)
       end
 
       it 'returns default params for empty string' do
-        expect(FixedFungibleTokenParamsExtractor.extract('')).to eq(default_params)
+        expect(Erc20FixedDenominationParser.extract('')).to eq(default_params)
       end
     end
 
     context 'non-string input types' do
       it 'returns default params for integer input' do
-        expect(FixedFungibleTokenParamsExtractor.extract(123)).to eq(default_params)
+        expect(Erc20FixedDenominationParser.extract(123)).to eq(default_params)
       end
 
       it 'returns default params for array input' do
-        expect(FixedFungibleTokenParamsExtractor.extract([])).to eq(default_params)
+        expect(Erc20FixedDenominationParser.extract([])).to eq(default_params)
       end
 
       it 'returns default params for hash input' do
-        expect(FixedFungibleTokenParamsExtractor.extract({})).to eq(default_params)
+        expect(Erc20FixedDenominationParser.extract({})).to eq(default_params)
       end
     end
   end

--- a/spec/models/erc721_ethscriptions_collection_parser_spec.rb
+++ b/spec/models/erc721_ethscriptions_collection_parser_spec.rb
@@ -1,13 +1,13 @@
 require 'rails_helper'
 
-RSpec.describe CollectionsParamsExtractor do
+RSpec.describe Erc721EthscriptionsCollectionParser do
   describe '#extract' do
     let(:default_params) { [''.b, ''.b, ''.b] }
 
     describe 'validation rules' do
       # @generic-compatible
       it 'requires data:, prefix' do
-        json = '{"p":"collections","op":"lock_collection","collection_id":"0x' + 'a' * 64 + '"}'
+        json = '{"p":"erc-721-ethscriptions-collection","op":"lock_collection","collection_id":"0x' + 'a' * 64 + '"}'
         result = described_class.extract(json)
         expect(result).to eq(default_params)
       end
@@ -18,14 +18,14 @@ RSpec.describe CollectionsParamsExtractor do
         expect(result).to eq(default_params)
       end
 
-      it 'requires p:collections' do
+      it 'requires p:erc-721-ethscriptions-collection' do
         json = 'data:,{"p":"other","op":"lock_collection","collection_id":"0x' + 'a' * 64 + '"}'
         result = described_class.extract(json)
         expect(result).to eq(default_params)
       end
 
       it 'requires known operation' do
-        json = 'data:,{"p":"collections","op":"unknown_op","collection_id":"0x' + 'a' * 64 + '"}'
+        json = 'data:,{"p":"erc-721-ethscriptions-collection","op":"unknown_op","collection_id":"0x' + 'a' * 64 + '"}'
         result = described_class.extract(json)
         expect(result).to eq(default_params)
       end
@@ -33,23 +33,23 @@ RSpec.describe CollectionsParamsExtractor do
       # @generic-compatible
       it 'enforces exact key order with p and op first' do
         # Wrong order - op before p
-        json1 = 'data:,{"op":"lock_collection","p":"collections","collection_id":"0x' + 'a' * 64 + '"}'
+        json1 = 'data:,{"op":"lock_collection","p":"erc-721-ethscriptions-collection","collection_id":"0x' + 'a' * 64 + '"}'
         expect(described_class.extract(json1)).to eq(default_params)
 
         # Wrong order - collection_id before op
-        json2 = 'data:,{"p":"collections","collection_id":"0x' + 'a' * 64 + '","op":"lock_collection"}'
+        json2 = 'data:,{"p":"erc-721-ethscriptions-collection","collection_id":"0x' + 'a' * 64 + '","op":"lock_collection"}'
         expect(described_class.extract(json2)).to eq(default_params)
 
         # Correct order
-        json3 = 'data:,{"p":"collections","op":"lock_collection","collection_id":"0x' + 'a' * 64 + '"}'
+        json3 = 'data:,{"p":"erc-721-ethscriptions-collection","op":"lock_collection","collection_id":"0x' + 'a' * 64 + '"}'
         result = described_class.extract(json3)
-        expect(result[0]).to eq('collections'.b)
+        expect(result[0]).to eq('erc-721-ethscriptions-collection'.b)
         expect(result[1]).to eq('lock_collection'.b)
       end
 
       # @generic-compatible
       it 'rejects extra keys' do
-        json = 'data:,{"p":"collections","op":"lock_collection","collection_id":"0x' + 'a' * 64 + '","extra":"field"}'
+        json = 'data:,{"p":"erc-721-ethscriptions-collection","op":"lock_collection","collection_id":"0x' + 'a' * 64 + '","extra":"field"}'
         result = described_class.extract(json)
         expect(result).to eq(default_params)
       end
@@ -57,12 +57,12 @@ RSpec.describe CollectionsParamsExtractor do
       # @generic-compatible
       it 'validates uint256 format - no leading zeros' do
         # Valid
-        valid_json = 'data:,{"p":"collections","op":"create_collection","name":"Test","symbol":"TEST","total_supply":"1000","description":"","logo_image_uri":"","banner_image_uri":"","background_color":"","website_link":"","twitter_link":"","discord_link":""}'
+        valid_json = 'data:,{"p":"erc-721-ethscriptions-collection","op":"create_collection","name":"Test","symbol":"TEST","total_supply":"1000","description":"","logo_image_uri":"","banner_image_uri":"","background_color":"","website_link":"","twitter_link":"","discord_link":""}'
         result = described_class.extract(valid_json)
-        expect(result[0]).to eq('collections'.b)
+        expect(result[0]).to eq('erc-721-ethscriptions-collection'.b)
 
         # Invalid - leading zero
-        invalid_json = 'data:,{"p":"collections","op":"create_collection","name":"Test","symbol":"TEST","total_supply":"01000","description":"","logo_image_uri":"","banner_image_uri":"","background_color":"","website_link":"","twitter_link":"","discord_link":""}'
+        invalid_json = 'data:,{"p":"erc-721-ethscriptions-collection","op":"create_collection","name":"Test","symbol":"TEST","total_supply":"01000","description":"","logo_image_uri":"","banner_image_uri":"","background_color":"","website_link":"","twitter_link":"","discord_link":""}'
         result = described_class.extract(invalid_json)
         expect(result).to eq(default_params)
       end
@@ -70,22 +70,22 @@ RSpec.describe CollectionsParamsExtractor do
       # @generic-compatible
       it 'validates bytes32 format - lowercase hex only' do
         # Valid lowercase
-        valid_json = 'data:,{"p":"collections","op":"lock_collection","collection_id":"0x' + 'a' * 64 + '"}'
+        valid_json = 'data:,{"p":"erc-721-ethscriptions-collection","op":"lock_collection","collection_id":"0x' + 'a' * 64 + '"}'
         result = described_class.extract(valid_json)
-        expect(result[0]).to eq('collections'.b)
+        expect(result[0]).to eq('erc-721-ethscriptions-collection'.b)
 
         # Invalid - uppercase
-        invalid_json = 'data:,{"p":"collections","op":"lock_collection","collection_id":"0x' + 'A' * 64 + '"}'
+        invalid_json = 'data:,{"p":"erc-721-ethscriptions-collection","op":"lock_collection","collection_id":"0x' + 'A' * 64 + '"}'
         result = described_class.extract(invalid_json)
         expect(result).to eq(default_params)
 
         # Invalid - wrong length
-        invalid_json2 = 'data:,{"p":"collections","op":"lock_collection","collection_id":"0x' + 'a' * 63 + '"}'
+        invalid_json2 = 'data:,{"p":"erc-721-ethscriptions-collection","op":"lock_collection","collection_id":"0x' + 'a' * 63 + '"}'
         result = described_class.extract(invalid_json2)
         expect(result).to eq(default_params)
 
         # Invalid - no 0x prefix
-        invalid_json3 = 'data:,{"p":"collections","op":"lock_collection","collection_id":"' + 'a' * 64 + '"}'
+        invalid_json3 = 'data:,{"p":"erc-721-ethscriptions-collection","op":"lock_collection","collection_id":"' + 'a' * 64 + '"}'
         result = described_class.extract(invalid_json3)
         expect(result).to eq(default_params)
       end
@@ -93,13 +93,13 @@ RSpec.describe CollectionsParamsExtractor do
 
     describe 'create_collection operation' do
       let(:valid_create_json) do
-        'data:,{"p":"collections","op":"create_collection","name":"My Collection","symbol":"MYC","total_supply":"10000","description":"A test collection","logo_image_uri":"esc://logo","banner_image_uri":"esc://banner","background_color":"#FF5733","website_link":"https://example.com","twitter_link":"https://twitter.com/test","discord_link":"https://discord.gg/test"}'
+        'data:,{"p":"erc-721-ethscriptions-collection","op":"create_collection","name":"My Collection","symbol":"MYC","total_supply":"10000","description":"A test collection","logo_image_uri":"esc://logo","banner_image_uri":"esc://banner","background_color":"#FF5733","website_link":"https://example.com","twitter_link":"https://twitter.com/test","discord_link":"https://discord.gg/test"}'
       end
 
       it 'encodes create_collection correctly' do
         result = described_class.extract(valid_create_json)
 
-        expect(result[0]).to eq('collections'.b)
+        expect(result[0]).to eq('erc-721-ethscriptions-collection'.b)
         expect(result[1]).to eq('create_collection'.b)
 
         # Decode and verify
@@ -121,10 +121,10 @@ RSpec.describe CollectionsParamsExtractor do
       end
 
       it 'handles empty optional fields' do
-        json = 'data:,{"p":"collections","op":"create_collection","name":"Test","symbol":"TST","total_supply":"100","description":"","logo_image_uri":"","banner_image_uri":"","background_color":"","website_link":"","twitter_link":"","discord_link":""}'
+        json = 'data:,{"p":"erc-721-ethscriptions-collection","op":"create_collection","name":"Test","symbol":"TST","total_supply":"100","description":"","logo_image_uri":"","banner_image_uri":"","background_color":"","website_link":"","twitter_link":"","discord_link":""}'
         result = described_class.extract(json)
 
-        expect(result[0]).to eq('collections'.b)
+        expect(result[0]).to eq('erc-721-ethscriptions-collection'.b)
         expect(result[1]).to eq('create_collection'.b)
 
         decoded = Eth::Abi.decode(
@@ -142,7 +142,7 @@ RSpec.describe CollectionsParamsExtractor do
         # Value that exceeds uint256 max
         too_large = (2**256).to_s  # One more than max
 
-        json = 'data:,{"p":"collections","op":"create_collection","name":"Test","symbol":"TST","total_supply":"' + too_large + '","description":"","logo_image_uri":"","banner_image_uri":"","background_color":"","website_link":"","twitter_link":"","discord_link":""}'
+        json = 'data:,{"p":"erc-721-ethscriptions-collection","op":"create_collection","name":"Test","symbol":"TST","total_supply":"' + too_large + '","description":"","logo_image_uri":"","banner_image_uri":"","background_color":"","website_link":"","twitter_link":"","discord_link":""}'
         result = described_class.extract(json)
 
         # Should return default params due to validation failure
@@ -153,11 +153,11 @@ RSpec.describe CollectionsParamsExtractor do
         # Maximum valid uint256
         max_uint256 = (2**256 - 1).to_s
 
-        json = 'data:,{"p":"collections","op":"create_collection","name":"Test","symbol":"TST","total_supply":"' + max_uint256 + '","description":"","logo_image_uri":"","banner_image_uri":"","background_color":"","website_link":"","twitter_link":"","discord_link":""}'
+        json = 'data:,{"p":"erc-721-ethscriptions-collection","op":"create_collection","name":"Test","symbol":"TST","total_supply":"' + max_uint256 + '","description":"","logo_image_uri":"","banner_image_uri":"","background_color":"","website_link":"","twitter_link":"","discord_link":""}'
         result = described_class.extract(json)
 
         # Should succeed with max value
-        expect(result[0]).to eq('collections'.b)
+        expect(result[0]).to eq('erc-721-ethscriptions-collection'.b)
         expect(result[1]).to eq('create_collection'.b)
 
         decoded = Eth::Abi.decode(
@@ -171,13 +171,13 @@ RSpec.describe CollectionsParamsExtractor do
 
     describe 'add_items_batch operation' do
       let(:valid_add_items_json) do
-        'data:,{"p":"collections","op":"add_items_batch","collection_id":"0x' + '1' * 64 + '","items":[{"item_index":"0","name":"Item 1","ethscription_id":"0x' + '2' * 64 + '","background_color":"#FF0000","description":"First item","attributes":[{"trait_type":"Rarity","value":"Common"},{"trait_type":"Level","value":"1"}]}]}'
+        'data:,{"p":"erc-721-ethscriptions-collection","op":"add_items_batch","collection_id":"0x' + '1' * 64 + '","items":[{"item_index":"0","name":"Item 1","ethscription_id":"0x' + '2' * 64 + '","background_color":"#FF0000","description":"First item","attributes":[{"trait_type":"Rarity","value":"Common"},{"trait_type":"Level","value":"1"}]}]}'
       end
 
       it 'encodes add_items_batch correctly' do
         result = described_class.extract(valid_add_items_json)
 
-        expect(result[0]).to eq('collections'.b)
+        expect(result[0]).to eq('erc-721-ethscriptions-collection'.b)
         expect(result[1]).to eq('add_items_batch'.b)
 
         # Decode and verify
@@ -199,23 +199,23 @@ RSpec.describe CollectionsParamsExtractor do
 
       it 'validates item key order' do
         # Wrong key order in item
-        json = 'data:,{"p":"collections","op":"add_items_batch","collection_id":"0x' + '1' * 64 + '","items":[{"name":"Item 1","item_index":"0","ethscription_id":"0x' + '2' * 64 + '","background_color":"#FF0000","description":"First item","attributes":[]}]}'
+        json = 'data:,{"p":"erc-721-ethscriptions-collection","op":"add_items_batch","collection_id":"0x' + '1' * 64 + '","items":[{"name":"Item 1","item_index":"0","ethscription_id":"0x' + '2' * 64 + '","background_color":"#FF0000","description":"First item","attributes":[]}]}'
         result = described_class.extract(json)
         expect(result).to eq(default_params)
       end
 
       it 'validates attribute key order' do
         # Wrong key order in attributes (value before trait_type)
-        json = 'data:,{"p":"collections","op":"add_items_batch","collection_id":"0x' + '1' * 64 + '","items":[{"item_index":"0","name":"Item 1","ethscription_id":"0x' + '2' * 64 + '","background_color":"#FF0000","description":"First item","attributes":[{"value":"Common","trait_type":"Rarity"}]}]}'
+        json = 'data:,{"p":"erc-721-ethscriptions-collection","op":"add_items_batch","collection_id":"0x' + '1' * 64 + '","items":[{"item_index":"0","name":"Item 1","ethscription_id":"0x' + '2' * 64 + '","background_color":"#FF0000","description":"First item","attributes":[{"value":"Common","trait_type":"Rarity"}]}]}'
         result = described_class.extract(json)
         expect(result).to eq(default_params)
       end
 
       it 'handles empty attributes array' do
-        json = 'data:,{"p":"collections","op":"add_items_batch","collection_id":"0x' + '1' * 64 + '","items":[{"item_index":"0","name":"Item 1","ethscription_id":"0x' + '2' * 64 + '","background_color":"","description":"","attributes":[]}]}'
+        json = 'data:,{"p":"erc-721-ethscriptions-collection","op":"add_items_batch","collection_id":"0x' + '1' * 64 + '","items":[{"item_index":"0","name":"Item 1","ethscription_id":"0x' + '2' * 64 + '","background_color":"","description":"","attributes":[]}]}'
         result = described_class.extract(json)
 
-        expect(result[0]).to eq('collections'.b)
+        expect(result[0]).to eq('erc-721-ethscriptions-collection'.b)
 
         decoded = Eth::Abi.decode(
           ['(bytes32,(uint256,string,bytes32,string,string,(string,string)[])[])'],
@@ -227,13 +227,13 @@ RSpec.describe CollectionsParamsExtractor do
       end
 
       it 'handles multiple items' do
-        json = 'data:,{"p":"collections","op":"add_items_batch","collection_id":"0x' + '1' * 64 + '","items":[' +
+        json = 'data:,{"p":"erc-721-ethscriptions-collection","op":"add_items_batch","collection_id":"0x' + '1' * 64 + '","items":[' +
           '{"item_index":"0","name":"Item 1","ethscription_id":"0x' + '2' * 64 + '","background_color":"","description":"","attributes":[]},' +
           '{"item_index":"1","name":"Item 2","ethscription_id":"0x' + '3' * 64 + '","background_color":"","description":"","attributes":[]}' +
           ']}'
         result = described_class.extract(json)
 
-        expect(result[0]).to eq('collections'.b)
+        expect(result[0]).to eq('erc-721-ethscriptions-collection'.b)
 
         decoded = Eth::Abi.decode(
           ['(bytes32,(uint256,string,bytes32,string,string,(string,string)[])[])'],
@@ -248,10 +248,10 @@ RSpec.describe CollectionsParamsExtractor do
 
     describe 'remove_items operation' do
       it 'encodes remove_items correctly' do
-        json = 'data:,{"p":"collections","op":"remove_items","collection_id":"0x' + '1' * 64 + '","ethscription_ids":["0x' + '2' * 64 + '","0x' + '3' * 64 + '"]}'
+        json = 'data:,{"p":"erc-721-ethscriptions-collection","op":"remove_items","collection_id":"0x' + '1' * 64 + '","ethscription_ids":["0x' + '2' * 64 + '","0x' + '3' * 64 + '"]}'
         result = described_class.extract(json)
 
-        expect(result[0]).to eq('collections'.b)
+        expect(result[0]).to eq('erc-721-ethscriptions-collection'.b)
         expect(result[1]).to eq('remove_items'.b)
 
         decoded = Eth::Abi.decode(['(bytes32,bytes32[])'], result[2])[0]
@@ -264,10 +264,10 @@ RSpec.describe CollectionsParamsExtractor do
 
     describe 'edit_collection operation' do
       it 'encodes edit_collection correctly' do
-        json = 'data:,{"p":"collections","op":"edit_collection","collection_id":"0x' + '1' * 64 + '","description":"Updated","logo_image_uri":"new_logo","banner_image_uri":"","background_color":"#00FF00","website_link":"https://new.com","twitter_link":"","discord_link":""}'
+        json = 'data:,{"p":"erc-721-ethscriptions-collection","op":"edit_collection","collection_id":"0x' + '1' * 64 + '","description":"Updated","logo_image_uri":"new_logo","banner_image_uri":"","background_color":"#00FF00","website_link":"https://new.com","twitter_link":"","discord_link":""}'
         result = described_class.extract(json)
 
-        expect(result[0]).to eq('collections'.b)
+        expect(result[0]).to eq('erc-721-ethscriptions-collection'.b)
         expect(result[1]).to eq('edit_collection'.b)
 
         decoded = Eth::Abi.decode(
@@ -286,10 +286,10 @@ RSpec.describe CollectionsParamsExtractor do
 
     describe 'edit_collection_item operation' do
       it 'encodes edit_collection_item correctly' do
-        json = 'data:,{"p":"collections","op":"edit_collection_item","collection_id":"0x' + '1' * 64 + '","item_index":"5","name":"Updated Name","background_color":"#0000FF","description":"Updated desc","attributes":[{"trait_type":"New","value":"Value"}]}'
+        json = 'data:,{"p":"erc-721-ethscriptions-collection","op":"edit_collection_item","collection_id":"0x' + '1' * 64 + '","item_index":"5","name":"Updated Name","background_color":"#0000FF","description":"Updated desc","attributes":[{"trait_type":"New","value":"Value"}]}'
         result = described_class.extract(json)
 
-        expect(result[0]).to eq('collections'.b)
+        expect(result[0]).to eq('erc-721-ethscriptions-collection'.b)
         expect(result[1]).to eq('edit_collection_item'.b)
 
         decoded = Eth::Abi.decode(
@@ -308,10 +308,10 @@ RSpec.describe CollectionsParamsExtractor do
 
     describe 'lock_collection operation' do
       it 'encodes lock_collection as single bytes32' do
-        json = 'data:,{"p":"collections","op":"lock_collection","collection_id":"0x' + '1' * 64 + '"}'
+        json = 'data:,{"p":"erc-721-ethscriptions-collection","op":"lock_collection","collection_id":"0x' + '1' * 64 + '"}'
         result = described_class.extract(json)
 
-        expect(result[0]).to eq('collections'.b)
+        expect(result[0]).to eq('erc-721-ethscriptions-collection'.b)
         expect(result[1]).to eq('lock_collection'.b)
 
         # Single bytes32, not a tuple
@@ -322,10 +322,10 @@ RSpec.describe CollectionsParamsExtractor do
 
     describe 'sync_ownership operation' do
       it 'encodes sync_ownership correctly' do
-        json = 'data:,{"p":"collections","op":"sync_ownership","collection_id":"0x' + '1' * 64 + '","ethscription_ids":["0x' + '2' * 64 + '"]}'
+        json = 'data:,{"p":"erc-721-ethscriptions-collection","op":"sync_ownership","collection_id":"0x' + '1' * 64 + '","ethscription_ids":["0x' + '2' * 64 + '"]}'
         result = described_class.extract(json)
 
-        expect(result[0]).to eq('collections'.b)
+        expect(result[0]).to eq('erc-721-ethscriptions-collection'.b)
         expect(result[1]).to eq('sync_ownership'.b)
 
         decoded = Eth::Abi.decode(['(bytes32,bytes32[])'], result[2])[0]
@@ -340,12 +340,12 @@ RSpec.describe CollectionsParamsExtractor do
       it 'preserves all data through encode/decode cycle' do
         test_cases = [
           {
-            json: 'data:,{"p":"collections","op":"create_collection","name":"Test","symbol":"TST","total_supply":"100","description":"Desc","logo_image_uri":"logo","banner_image_uri":"banner","background_color":"#FFF","website_link":"http://test","twitter_link":"@test","discord_link":"discord"}',
+            json: 'data:,{"p":"erc-721-ethscriptions-collection","op":"create_collection","name":"Test","symbol":"TST","total_supply":"100","description":"Desc","logo_image_uri":"logo","banner_image_uri":"banner","background_color":"#FFF","website_link":"http://test","twitter_link":"@test","discord_link":"discord"}',
             abi_type: '(string,string,uint256,string,string,string,string,string,string,string)',
             expected: ["Test", "TST", 100, "Desc", "logo", "banner", "#FFF", "http://test", "@test", "discord"]
           },
           {
-            json: 'data:,{"p":"collections","op":"lock_collection","collection_id":"0x' + 'a' * 64 + '"}',
+            json: 'data:,{"p":"erc-721-ethscriptions-collection","op":"lock_collection","collection_id":"0x' + 'a' * 64 + '"}',
             abi_type: 'bytes32',
             expected: ['a' * 64].pack('H*')
           }
@@ -386,29 +386,29 @@ RSpec.describe CollectionsParamsExtractor do
 
       it 'rejects null values in string fields (no silent coercion)' do
         # Test null in create_collection string fields
-        json_with_null = 'data:,{"p":"collections","op":"create_collection","name":null,"symbol":"TEST","total_supply":"100","description":"","logo_image_uri":"","banner_image_uri":"","background_color":"","website_link":"","twitter_link":"","discord_link":""}'
+        json_with_null = 'data:,{"p":"erc-721-ethscriptions-collection","op":"create_collection","name":null,"symbol":"TEST","total_supply":"100","description":"","logo_image_uri":"","banner_image_uri":"","background_color":"","website_link":"","twitter_link":"","discord_link":""}'
         result = described_class.extract(json_with_null)
         expect(result).to eq(default_params)
 
         # Test null in description field
-        json_with_null_desc = 'data:,{"p":"collections","op":"create_collection","name":"Test","symbol":"TEST","total_supply":"100","description":null,"logo_image_uri":"","banner_image_uri":"","background_color":"","website_link":"","twitter_link":"","discord_link":""}'
+        json_with_null_desc = 'data:,{"p":"erc-721-ethscriptions-collection","op":"create_collection","name":"Test","symbol":"TEST","total_supply":"100","description":null,"logo_image_uri":"","banner_image_uri":"","background_color":"","website_link":"","twitter_link":"","discord_link":""}'
         result = described_class.extract(json_with_null_desc)
         expect(result).to eq(default_params)
 
         # Test null in item fields
-        json_with_null_item = 'data:,{"p":"collections","op":"add_items_batch","collection_id":"0x' + '1' * 64 + '","items":[{"item_index":"0","name":null,"ethscription_id":"0x' + '2' * 64 + '","background_color":"","description":"","attributes":[]}]}'
+        json_with_null_item = 'data:,{"p":"erc-721-ethscriptions-collection","op":"add_items_batch","collection_id":"0x' + '1' * 64 + '","items":[{"item_index":"0","name":null,"ethscription_id":"0x' + '2' * 64 + '","background_color":"","description":"","attributes":[]}]}'
         result = described_class.extract(json_with_null_item)
         expect(result).to eq(default_params)
 
         # Test null in attribute fields
-        json_with_null_attr = 'data:,{"p":"collections","op":"add_items_batch","collection_id":"0x' + '1' * 64 + '","items":[{"item_index":"0","name":"Item","ethscription_id":"0x' + '2' * 64 + '","background_color":"","description":"","attributes":[{"trait_type":null,"value":"test"}]}]}'
+        json_with_null_attr = 'data:,{"p":"erc-721-ethscriptions-collection","op":"add_items_batch","collection_id":"0x' + '1' * 64 + '","items":[{"item_index":"0","name":"Item","ethscription_id":"0x' + '2' * 64 + '","background_color":"","description":"","attributes":[{"trait_type":null,"value":"test"}]}]}'
         result = described_class.extract(json_with_null_attr)
         expect(result).to eq(default_params)
       end
 
       it 'returns default params for missing required fields' do
         # Missing collection_id
-        json = 'data:,{"p":"collections","op":"lock_collection"}'
+        json = 'data:,{"p":"erc-721-ethscriptions-collection","op":"lock_collection"}'
         result = described_class.extract(json)
         expect(result).to eq(default_params)
       end

--- a/spec/models/ethscription_transaction_builder_spec.rb
+++ b/spec/models/ethscription_transaction_builder_spec.rb
@@ -5,41 +5,41 @@ RSpec.describe "EthscriptionTransactionBuilder" do
     it 'extracts deploy operation params' do
       content_uri = 'data:,{"p":"erc-20","op":"deploy","tick":"eths","max":"21000000","lim":"1000"}'
 
-      params = FixedFungibleTokenParamsExtractor.extract(content_uri)
+      params = Erc20FixedDenominationParser.extract(content_uri)
 
-      expect(params).to eq(['deploy', 'fixed-fungible', 'eths', 21000000, 1000, 0])
+      expect(params).to eq(['deploy'.b, 'erc-20-fixed-denomination'.b, 'eths'.b, 21000000, 1000, 0])
     end
 
     it 'extracts mint operation params' do
       content_uri = 'data:,{"p":"erc-20","op":"mint","tick":"eths","id":"1","amt":"1000"}'
 
-      params = FixedFungibleTokenParamsExtractor.extract(content_uri)
+      params = Erc20FixedDenominationParser.extract(content_uri)
 
-      expect(params).to eq(['mint', 'fixed-fungible', 'eths', 1, 0, 1000])
+      expect(params).to eq(['mint'.b, 'erc-20-fixed-denomination'.b, 'eths'.b, 1, 0, 1000])
     end
 
     it 'returns default params for non-token content' do
       content_uri = 'data:,Hello World!'
 
-      params = FixedFungibleTokenParamsExtractor.extract(content_uri)
+      params = Erc20FixedDenominationParser.extract(content_uri)
 
-      expect(params).to eq(['', '', '', 0, 0, 0])
+      expect(params).to eq([''.b, ''.b, ''.b, 0, 0, 0])
     end
 
     it 'returns default params for invalid JSON' do
       content_uri = 'data:,{invalid json'
 
-      params = FixedFungibleTokenParamsExtractor.extract(content_uri)
+      params = Erc20FixedDenominationParser.extract(content_uri)
 
-      expect(params).to eq(['', '', '', 0, 0, 0])
+      expect(params).to eq([''.b, ''.b, ''.b, 0, 0, 0])
     end
 
     it 'handles unknown operations with protocol/tick' do
       content_uri = 'data:,{"p":"new-proto","op":"custom","tick":"test"}'
 
-      params = FixedFungibleTokenParamsExtractor.extract(content_uri)
+      params = Erc20FixedDenominationParser.extract(content_uri)
 
-      expect(params).to eq(["", "", "", 0, 0, 0])
+      expect(params).to eq([''.b, ''.b, ''.b, 0, 0, 0])
     end
   end
 end

--- a/spec/models/generic_protocol_extractor_collections_spec.rb
+++ b/spec/models/generic_protocol_extractor_collections_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe GenericProtocolExtractor do
     describe 'create_collection' do
       it 'encodes create_collection with all string parameters' do
         json = {
-          "p" => "collections",
+          "p" => "erc-721-ethscriptions-collection",
           "op" => "create_collection",
           "name" => "Test Collection",
           "symbol" => "TEST",
@@ -22,7 +22,7 @@ RSpec.describe GenericProtocolExtractor do
         content_uri = "data:," + json.to_json
         result = described_class.extract(content_uri)
 
-        expect(result[0]).to eq("collections")
+        expect(result[0]).to eq("erc-721-ethscriptions-collection")
         expect(result[1]).to eq("create_collection")
         expect(result[2]).not_to be_empty
 
@@ -48,7 +48,7 @@ RSpec.describe GenericProtocolExtractor do
     describe 'add_items_batch with nested arrays' do
       it 'preserves nested attribute arrays as string[][]' do
         json = {
-          "p" => "collections",
+          "p" => "erc-721-ethscriptions-collection",
           "op" => "add_items_batch",
           "collectionId" => "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
           "items" => [
@@ -70,7 +70,7 @@ RSpec.describe GenericProtocolExtractor do
         content_uri = "data:," + json.to_json
         result = described_class.extract(content_uri)
 
-        expect(result[0]).to eq("collections")
+        expect(result[0]).to eq("erc-721-ethscriptions-collection")
         expect(result[1]).to eq("add_items_batch")
         expect(result[2]).not_to be_empty
 
@@ -98,7 +98,7 @@ RSpec.describe GenericProtocolExtractor do
 
       it 'handles empty attributes array' do
         json = {
-          "p" => "collections",
+          "p" => "erc-721-ethscriptions-collection",
           "op" => "add_items_batch",
           "collectionId" => "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
           "items" => [
@@ -116,14 +116,14 @@ RSpec.describe GenericProtocolExtractor do
         content_uri = "data:," + json.to_json
         result = described_class.extract(content_uri)
 
-        expect(result[0]).to eq("collections")
+        expect(result[0]).to eq("erc-721-ethscriptions-collection")
         expect(result[1]).to eq("add_items_batch")
         expect(result[2]).not_to be_empty
       end
 
       it 'accepts standard NFT attribute format' do
         json = {
-          "p" => "collections",
+          "p" => "erc-721-ethscriptions-collection",
           "op" => "add_items_batch",
           "collectionId" => "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
           "items" => [
@@ -145,7 +145,7 @@ RSpec.describe GenericProtocolExtractor do
         content_uri = "data:," + json.to_json
         result = described_class.extract(content_uri)
 
-        expect(result[0]).to eq("collections")
+        expect(result[0]).to eq("erc-721-ethscriptions-collection")
         expect(result[1]).to eq("add_items_batch")
         expect(result[2]).not_to be_empty
 
@@ -165,7 +165,7 @@ RSpec.describe GenericProtocolExtractor do
 
       it 'accepts object format for better readability' do
         json = {
-          "p" => "collections",
+          "p" => "erc-721-ethscriptions-collection",
           "op" => "add_items_batch",
           "collectionId" => "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
           "items" => [
@@ -187,7 +187,7 @@ RSpec.describe GenericProtocolExtractor do
         content_uri = "data:," + json.to_json
         result = described_class.extract(content_uri)
 
-        expect(result[0]).to eq("collections")
+        expect(result[0]).to eq("erc-721-ethscriptions-collection")
         expect(result[1]).to eq("add_items_batch")
         expect(result[2]).not_to be_empty
 
@@ -208,7 +208,7 @@ RSpec.describe GenericProtocolExtractor do
 
       it 'validates consistent inner array sizes for attributes' do
         json = {
-          "p" => "collections",
+          "p" => "erc-721-ethscriptions-collection",
           "op" => "add_items_batch",
           "collectionId" => "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
           "items" => [
@@ -235,7 +235,7 @@ RSpec.describe GenericProtocolExtractor do
 
       it 'handles numeric values in attributes properly' do
         json = {
-          "p" => "collections",
+          "p" => "erc-721-ethscriptions-collection",
           "op" => "add_items_batch",
           "collectionId" => "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
           "items" => [
@@ -256,7 +256,7 @@ RSpec.describe GenericProtocolExtractor do
         content_uri = "data:," + json.to_json
         result = described_class.extract(content_uri)
 
-        expect(result[0]).to eq("collections")
+        expect(result[0]).to eq("erc-721-ethscriptions-collection")
         expect(result[1]).to eq("add_items_batch")
         expect(result[2]).not_to be_empty
 
@@ -274,7 +274,7 @@ RSpec.describe GenericProtocolExtractor do
     describe 'edit_collection' do
       it 'encodes edit_collection operation with flattened structure' do
         json = {
-          "p" => "collections",
+          "p" => "erc-721-ethscriptions-collection",
           "op" => "edit_collection",
           "collectionId" => "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
           "description" => "Updated description",
@@ -289,7 +289,7 @@ RSpec.describe GenericProtocolExtractor do
         content_uri = "data:," + json.to_json
         result = described_class.extract(content_uri)
 
-        expect(result[0]).to eq("collections")
+        expect(result[0]).to eq("erc-721-ethscriptions-collection")
         expect(result[1]).to eq("edit_collection")
         expect(result[2]).not_to be_empty
 
@@ -313,7 +313,7 @@ RSpec.describe GenericProtocolExtractor do
     describe 'edit_collection_item' do
       it 'encodes edit_collection_item with updated attributes' do
         json = {
-          "p" => "collections",
+          "p" => "erc-721-ethscriptions-collection",
           "op" => "edit_collection_item",
           "collectionId" => "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
           "itemIndex" => "42",
@@ -329,7 +329,7 @@ RSpec.describe GenericProtocolExtractor do
         content_uri = "data:," + json.to_json
         result = described_class.extract(content_uri)
 
-        expect(result[0]).to eq("collections")
+        expect(result[0]).to eq("erc-721-ethscriptions-collection")
         expect(result[1]).to eq("edit_collection_item")
         expect(result[2]).not_to be_empty
 
@@ -351,7 +351,7 @@ RSpec.describe GenericProtocolExtractor do
     describe 'bytes32 handling' do
       it 'correctly encodes bytes32 values' do
         json = {
-          "p" => "collections",
+          "p" => "erc-721-ethscriptions-collection",
           "op" => "remove_items",
           "collectionId" => "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
           "ethscriptionIds" => [
@@ -363,7 +363,7 @@ RSpec.describe GenericProtocolExtractor do
         content_uri = "data:," + json.to_json
         result = described_class.extract(content_uri)
 
-        expect(result[0]).to eq("collections")
+        expect(result[0]).to eq("erc-721-ethscriptions-collection")
         expect(result[1]).to eq("remove_items")
 
         # Verify bytes32 encoding - now as tuple
@@ -414,7 +414,7 @@ RSpec.describe GenericProtocolExtractor do
     describe 'numeric string handling' do
       it 'converts numeric strings to uint256' do
         json = {
-          "p" => "collections",
+          "p" => "erc-721-ethscriptions-collection",
           "op" => "test",
           "totalSupply" => "10000",
           "maxSize" => "999999999",

--- a/spec/models/generic_protocol_extractor_spec.rb
+++ b/spec/models/generic_protocol_extractor_spec.rb
@@ -6,11 +6,11 @@ RSpec.describe GenericProtocolExtractor do
   describe '.extract' do
     context 'collections protocol' do
       it 'extracts createCollection operation with string numbers' do
-        content_uri = 'data:,{"p":"collections","op":"create_collection","name":"My NFTs","symbol":"MNFT","maxSupply":"10000","baseUri":"https://api.example.com/"}'
+        content_uri = 'data:,{"p":"erc-721-ethscriptions-collection","op":"create_collection","name":"My NFTs","symbol":"MNFT","maxSupply":"10000","baseUri":"https://api.example.com/"}'
 
         protocol, operation, encoded_data = GenericProtocolExtractor.extract(content_uri)
 
-        expect(protocol).to eq('collections'.b)
+        expect(protocol).to eq('erc-721-ethscriptions-collection'.b)
         expect(operation).to eq('create_collection'.b)
 
         # Decode to verify encoding - order matches JSON field order
@@ -26,11 +26,11 @@ RSpec.describe GenericProtocolExtractor do
       end
 
       it 'handles add_members operation with address arrays' do
-        content_uri = 'data:,{"p":"collections","op":"add_members","collectionId":"0x1234567890abcdef1234567890abcdef12345678","members":["0x742d35Cc6634C0532925a3b844Bc9e7595f0bEb1","0x5aAeb6053f3E94C9b9A09f33669435E7Ef1BeAed"]}'
+        content_uri = 'data:,{"p":"erc-721-ethscriptions-collection","op":"add_members","collectionId":"0x1234567890abcdef1234567890abcdef12345678","members":["0x742d35Cc6634C0532925a3b844Bc9e7595f0bEb1","0x5aAeb6053f3E94C9b9A09f33669435E7Ef1BeAed"]}'
 
         protocol, operation, encoded_data = GenericProtocolExtractor.extract(content_uri)
 
-        expect(protocol).to eq('collections'.b)
+        expect(protocol).to eq('erc-721-ethscriptions-collection'.b)
         expect(operation).to eq('add_members'.b)
 
         # Arrays are supported - now encoded as tuple
@@ -433,13 +433,13 @@ RSpec.describe GenericProtocolExtractor do
     end
 
     context 'fixed fungible extraction helper' do
-      it 'uses FixedFungibleTokenParamsExtractor for erc-20 inscriptions' do
+      it 'uses Erc20FixedDenominationParser for erc-20 inscriptions' do
         content_uri = 'data:,{"p":"erc-20","op":"mint","tick":"punk","id":"1","amt":"100"}'
 
         # The token protocol should still use its strict extractor
         token_params = GenericProtocolExtractor.extract_token_params(content_uri)
 
-        expect(token_params).to eq(['mint'.b, 'fixed-fungible'.b, 'punk'.b, 1, 0, 100])
+        expect(token_params).to eq(['mint'.b, 'erc-20-fixed-denomination'.b, 'punk'.b, 1, 0, 100])
       end
     end
 

--- a/spec/models/generic_protocol_extractor_type_hints_spec.rb
+++ b/spec/models/generic_protocol_extractor_type_hints_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe GenericProtocolExtractor, 'type hints' do
   describe 'with type hint arrays' do
     it 'handles empty array with type hint' do
       json = {
-        "p" => "collections",
+        "p" => "erc-721-ethscriptions-collection",
         "op" => "edit_item",
         "collectionId" => "0x1234",
         "itemIndex" => 42,
@@ -15,7 +15,7 @@ RSpec.describe GenericProtocolExtractor, 'type hints' do
       content_uri = "data:," + json.to_json
       result = described_class.extract(content_uri)
 
-      expect(result[0]).to eq('collections'.b)
+      expect(result[0]).to eq('erc-721-ethscriptions-collection'.b)
       expect(result[1]).to eq('edit_item'.b)
 
       # Decode the ABI data - now as tuple
@@ -28,7 +28,7 @@ RSpec.describe GenericProtocolExtractor, 'type hints' do
 
     it 'handles non-empty array with type hint' do
       json = {
-        "p" => "collections",
+        "p" => "erc-721-ethscriptions-collection",
         "op" => "edit_item",
         "attributes" => ["(string,string)[]", [
           {"trait_type" => "Color", "value" => "Red"},
@@ -108,7 +108,7 @@ RSpec.describe GenericProtocolExtractor, 'type hints' do
 
     it 'still works without type hints (backward compatible)' do
       json = {
-        "p" => "collections",
+        "p" => "erc-721-ethscriptions-collection",
         "op" => "edit_item",
         "name" => "Test",
         "attributes" => [

--- a/spec/models/protocol_extractor_spec.rb
+++ b/spec/models/protocol_extractor_spec.rb
@@ -2,29 +2,29 @@ require 'rails_helper'
 
 RSpec.describe ProtocolExtractor do
   describe '.extract' do
-    context 'fixed-fungible protocol (erc-20 inscriptions)' do
-      it 'delegates to FixedFungibleTokenParamsExtractor for valid deploy' do
+    context 'erc-20-fixed-denomination protocol (erc-20 inscriptions)' do
+      it 'delegates to Erc20FixedDenominationParser for valid deploy' do
         content_uri = 'data:,{"p":"erc-20","op":"deploy","tick":"punk","max":"21000000","lim":"1000"}'
 
         result = ProtocolExtractor.extract(content_uri)
 
         expect(result).not_to be_nil
-        expect(result[:type]).to eq(:fixed_fungible)
-        expect(result[:protocol]).to eq('fixed-fungible')
+        expect(result[:type]).to eq(:erc20_fixed_denomination)
+        expect(result[:protocol]).to eq('erc-20-fixed-denomination')
         expect(result[:operation]).to eq('deploy'.b)
-        expect(result[:params]).to eq(['deploy'.b, 'fixed-fungible'.b, 'punk'.b, 21000000, 1000, 0])
+        expect(result[:params]).to eq(['deploy'.b, 'erc-20-fixed-denomination'.b, 'punk'.b, 21000000, 1000, 0])
       end
 
-      it 'delegates to FixedFungibleTokenParamsExtractor for valid mint' do
+      it 'delegates to Erc20FixedDenominationParser for valid mint' do
         content_uri = 'data:,{"p":"erc-20","op":"mint","tick":"punk","id":"1","amt":"100"}'
 
         result = ProtocolExtractor.extract(content_uri)
 
         expect(result).not_to be_nil
-        expect(result[:type]).to eq(:fixed_fungible)
-        expect(result[:protocol]).to eq('fixed-fungible')
+        expect(result[:type]).to eq(:erc20_fixed_denomination)
+        expect(result[:protocol]).to eq('erc-20-fixed-denomination')
         expect(result[:operation]).to eq('mint'.b)
-        expect(result[:params]).to eq(['mint'.b, 'fixed-fungible'.b, 'punk'.b, 1, 0, 100])
+        expect(result[:params]).to eq(['mint'.b, 'erc-20-fixed-denomination'.b, 'punk'.b, 1, 0, 100])
       end
 
       it 'falls back to generic extractor for malformed token protocol' do
@@ -54,14 +54,14 @@ RSpec.describe ProtocolExtractor do
     end
 
     context 'generic protocols' do
-      it 'delegates to GenericProtocolExtractor for collections' do
-        content_uri = 'data:,{"p":"collections","op":"create_collection","name":"My NFTs","maxSupply":"10000"}'
+      it 'delegates to collections extractor for ERC-721 Ethscriptions collections' do
+        content_uri = 'data:,{"p":"erc-721-ethscriptions-collection","op":"create_collection","name":"My NFTs","maxSupply":"10000"}'
 
         result = ProtocolExtractor.extract(content_uri)
 
         expect(result).not_to be_nil
         expect(result[:type]).to eq(:generic)
-        expect(result[:protocol]).to eq('collections'.b)
+        expect(result[:protocol]).to eq('erc-721-ethscriptions-collection'.b)
         expect(result[:operation]).to eq('create_collection'.b)
         expect(result[:encoded_params]).not_to be_empty
       end
@@ -133,7 +133,7 @@ RSpec.describe ProtocolExtractor do
 
         result = ProtocolExtractor.for_calldata(content_uri)
 
-        expect(result[0]).to eq('fixed-fungible'.b)  # protocol
+        expect(result[0]).to eq('erc-20-fixed-denomination'.b)  # protocol
         expect(result[1]).to eq('deploy'.b)   # operation
         expect(result[2]).not_to be_empty     # encoded data
 
@@ -151,7 +151,7 @@ RSpec.describe ProtocolExtractor do
 
         result = ProtocolExtractor.for_calldata(content_uri)
 
-        expect(result[0]).to eq('fixed-fungible'.b)  # protocol
+        expect(result[0]).to eq('erc-20-fixed-denomination'.b)  # protocol
         expect(result[1]).to eq('mint'.b)     # operation
         expect(result[2]).not_to be_empty     # encoded data
 
@@ -174,11 +174,11 @@ RSpec.describe ProtocolExtractor do
 
       it 'returns extracted params for generic protocols' do
         # Generic protocols now return actual extracted data
-        content_uri = 'data:,{"p":"collections","op":"create","name":"Test"}'
+        content_uri = 'data:,{"p":"erc-721-ethscriptions-collection","op":"create","name":"Test"}'
 
         result = ProtocolExtractor.for_calldata(content_uri)
 
-        expect(result[0]).to eq('collections'.b)  # protocol
+        expect(result[0]).to eq('erc-721-ethscriptions-collection'.b)  # protocol
         expect(result[1]).to eq('create'.b)        # operation
         expect(result[2]).not_to be_empty          # encoded data
 
@@ -208,8 +208,8 @@ RSpec.describe ProtocolExtractor do
 
         result = ProtocolExtractor.extract(content_uri)
 
-        expect(result[:type]).to eq(:fixed_fungible)
-        expect(result[:protocol]).to eq('fixed-fungible')
+        expect(result[:type]).to eq(:erc20_fixed_denomination)
+        expect(result[:protocol]).to eq('erc-20-fixed-denomination')
       end
 
       it 'falls back to generic for erc-20 with non-standard operations' do


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Migrate token and collection protocols to new canonical names and contracts, updating parsers, extractors, predeploys/genesis, readers, events, and tests accordingly.
> 
> - **Protocols/Parsing**:
>   - Rename `fixed-fungible` → `erc-20-fixed-denomination`; `collections` → `erc-721-ethscriptions-collection` across parsers (`Erc20FixedDenominationParser`, `Erc721EthscriptionsCollectionParser`) with strict validation and ABI tuple encoding.
>   - Update `ProtocolExtractor` and `GenericProtocolExtractor` to use new parsers, types, and calldata encoding.
> - **Contracts/Genesis/Predeploys**:
>   - Add/rename contracts: `ERC20FixedDenomination`, `ERC20FixedDenominationManager`, `ERC721EthscriptionsCollection`, `ERC721EthscriptionsCollectionManager` with corresponding events and logic.
>   - Update `Predeploys` addresses, `L2Genesis` to set implementations and register protocols under new names.
>   - Adjust `Ethscriptions` interface/comments and handler interactions.
> - **Infra/Readers/Events**:
>   - Replace reader utilities with `Erc20FixedDenominationReader` and update `ProtocolEventReader` to new event signatures.
>   - Minor importer cleanup and `SysConfig` tidy.
> - **Tests**:
>   - Comprehensive test suite updates to new protocol names/contracts and behaviors across unit/integration tests.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7c5e457761e76836961a5527b109a500645de363. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->