### PR TITLE
Refactor Ethscription structure and retrieval methods

### DIFF
--- a/contracts/script/L2Genesis.s.sol
+++ b/contracts/script/L2Genesis.s.sol
@@ -43,7 +43,7 @@ contract GenesisEthscriptions is Ethscriptions {
         firstEthscriptionByContentUri[params.contentUriHash] = params.ethscriptionId;
 
         // Set all values including genesis-specific ones
-        ethscriptions[params.ethscriptionId] = Ethscription({
+        ethscriptions[params.ethscriptionId] = EthscriptionStorage({
             // Fixed-size fields
             contentUriHash: params.contentUriHash,
             contentSha: contentSha,

--- a/contracts/src/Ethscriptions.sol
+++ b/contracts/src/Ethscriptions.sol
@@ -17,13 +17,14 @@ import "./libraries/Constants.sol";
 /// @dev Uses ethscription number as token ID and name, while transaction hash remains the primary identifier for function calls
 contract Ethscriptions is ERC721EthscriptionsSequentialEnumerableUpgradeable {
     using LibString for *;
-    using EthscriptionsRendererLib for Ethscription;
+    using EthscriptionsRendererLib for EthscriptionStorage;
 
     // =============================================================
     //                          STRUCTS
     // =============================================================
 
-    struct Ethscription {
+    /// @notice Internal storage struct for ethscriptions (optimized for storage)
+    struct EthscriptionStorage {
         // Full slots
         bytes32 contentUriHash;
         bytes32 contentSha;
@@ -59,6 +60,35 @@ contract Ethscriptions is ERC721EthscriptionsSequentialEnumerableUpgradeable {
         ProtocolParams protocolParams;  // Protocol operation data (optional)
     }
 
+    /// @notice Complete denormalized ethscription data for external/off-chain consumption
+    /// @dev Includes all EthscriptionStorage fields plus owner and content
+    struct Ethscription {
+        // Identity
+        bytes32 ethscriptionId;        // L1 tx hash (the key)
+        uint256 ethscriptionNumber;    // Token ID
+
+        // Core metadata
+        bytes32 contentUriHash;
+        bytes32 contentSha;
+        string  mimetype;
+        bytes   content;               // Full content bytes (empty when includeContent=false)
+
+        // Ownership
+        address currentOwner;          // Current owner from ERC721 storage
+        address creator;
+        address initialOwner;
+        address previousOwner;
+
+        // Block/time data
+        bytes32 l1BlockHash;
+        uint256 l1BlockNumber;
+        uint256 l2BlockNumber;
+        uint256 createdAt;
+
+        // Protocol
+        bool    esip6;
+    }
+
     // =============================================================
     //                     CONSTANTS & IMMUTABLES
     // =============================================================
@@ -74,7 +104,7 @@ contract Ethscriptions is ERC721EthscriptionsSequentialEnumerableUpgradeable {
     // =============================================================
 
     /// @dev Ethscription ID (L1 tx hash) => Ethscription data
-    mapping(bytes32 => Ethscription) internal ethscriptions;
+    mapping(bytes32 => EthscriptionStorage) internal ethscriptions;
 
     /// @dev Content SHA => packed content (for <32 bytes) or SSTORE2 pointer (for >=32 bytes)
     mapping(bytes32 => bytes32) public contentStorageBySha;
@@ -163,16 +193,15 @@ contract Ethscriptions is ERC721EthscriptionsSequentialEnumerableUpgradeable {
     }
 
     /// @notice Resolve and validate an ethscription (by ID) or revert
-    function _getEthscriptionOrRevert(bytes32 ethscriptionId) internal view returns (Ethscription storage ethscription) {
+    function _getEthscriptionOrRevert(bytes32 ethscriptionId) internal view returns (EthscriptionStorage storage ethscription) {
         if (!_ethscriptionExists(ethscriptionId)) revert EthscriptionDoesNotExist();
         ethscription = ethscriptions[ethscriptionId];
     }
 
     /// @notice Resolve and validate an ethscription (by tokenId) or revert
-    function _getEthscriptionOrRevert(uint256 tokenId) internal view returns (Ethscription storage ethscription) {
+    function _getEthscriptionOrRevert(uint256 tokenId) internal view returns (EthscriptionStorage storage ethscription) {
         bytes32 id = tokenIdToEthscriptionId[tokenId];
-        if (!_ethscriptionExists(id)) revert TokenDoesNotExist();
-        ethscription = ethscriptions[id];
+        ethscription = _getEthscriptionOrRevert(id);
     }
 
     // =============================================================
@@ -218,7 +247,7 @@ contract Ethscriptions is ERC721EthscriptionsSequentialEnumerableUpgradeable {
         // Store content and get content SHA (of raw bytes)
         bytes32 contentSha = _storeContent(params.content);
 
-        ethscriptions[params.ethscriptionId] = Ethscription({
+        ethscriptions[params.ethscriptionId] = EthscriptionStorage({
             contentUriHash: params.contentUriHash,
             contentSha: contentSha,
             l1BlockHash: l1Block.hash(),
@@ -269,7 +298,7 @@ contract Ethscriptions is ERC721EthscriptionsSequentialEnumerableUpgradeable {
         bytes32 ethscriptionId
     ) external {
         // Load and validate
-        Ethscription storage ethscription = _getEthscriptionOrRevert(ethscriptionId);
+        EthscriptionStorage storage ethscription = _getEthscriptionOrRevert(ethscriptionId);
         uint256 tokenId = ethscription.ethscriptionNumber;
         // Standard ERC721 transfer will handle authorization
         transferFrom(msg.sender, to, tokenId);
@@ -285,7 +314,7 @@ contract Ethscriptions is ERC721EthscriptionsSequentialEnumerableUpgradeable {
         bytes32 ethscriptionId,
         address previousOwner
     ) external {
-        Ethscription storage ethscription = _getEthscriptionOrRevert(ethscriptionId);
+        EthscriptionStorage storage ethscription = _getEthscriptionOrRevert(ethscriptionId);
 
         // Verify the previous owner matches
         if (ethscription.previousOwner != previousOwner) {
@@ -308,7 +337,7 @@ contract Ethscriptions is ERC721EthscriptionsSequentialEnumerableUpgradeable {
         for (uint256 i = 0; i < ethscriptionIds.length; i++) {
             // Get the ethscription to find its token ID
             if (!_ethscriptionExists(ethscriptionIds[i])) continue; // Skip non-existent ethscriptions
-            Ethscription storage ethscription = ethscriptions[ethscriptionIds[i]];
+            EthscriptionStorage storage ethscription = ethscriptions[ethscriptionIds[i]];
 
             uint256 tokenId = ethscription.ethscriptionNumber;
 
@@ -344,11 +373,11 @@ contract Ethscriptions is ERC721EthscriptionsSequentialEnumerableUpgradeable {
     /// @notice Returns the full data URI for a token
     function tokenURI(uint256 tokenId) public view override returns (string memory) {
         // Find the ethscription for this token ID (ethscription number)
-        Ethscription storage ethscription = _getEthscriptionOrRevert(tokenId);
+        EthscriptionStorage storage ethscription = _getEthscriptionOrRevert(tokenId);
         bytes32 id = tokenIdToEthscriptionId[tokenId];
 
         // Get content
-        bytes memory content = getEthscriptionContent(id);
+        bytes memory content = _getEthscriptionContent(id);
 
         // Build complete token URI using the library - it handles everything internally
         return EthscriptionsRendererLib.buildTokenURI(ethscription, id, content);
@@ -359,21 +388,88 @@ contract Ethscriptions is ERC721EthscriptionsSequentialEnumerableUpgradeable {
     /// @return mediaType Either "image" or "animation_url"
     /// @return mediaUri The data URI for the media
     function getMediaUri(bytes32 ethscriptionId) external view returns (string memory mediaType, string memory mediaUri) {
-        Ethscription storage ethscription = _getEthscriptionOrRevert(ethscriptionId);
-        bytes memory content = getEthscriptionContent(ethscriptionId);
+        EthscriptionStorage storage ethscription = _getEthscriptionOrRevert(ethscriptionId);
+        bytes memory content = _getEthscriptionContent(ethscriptionId);
         return ethscription.getMediaUri(content);
     }
 
     // -------------------- Data Retrieval --------------------
 
-    /// @notice Get ethscription details (returns struct to avoid stack too deep)
-    function getEthscription(bytes32 ethscriptionId) external view returns (Ethscription memory) {
-        return _getEthscriptionOrRevert(ethscriptionId);
+    /// @notice Internal helper to build complete ethscription data
+    /// @param ethscriptionId The ethscription ID
+    /// @param includeContent Whether to include content bytes
+    /// @return complete The complete ethscription data
+    function _buildEthscription(bytes32 ethscriptionId, bool includeContent) internal view returns (Ethscription memory) {
+        EthscriptionStorage storage ethscription = _getEthscriptionOrRevert(ethscriptionId);
+
+        return Ethscription({
+            // Identity
+            ethscriptionId: ethscriptionId,
+            ethscriptionNumber: uint256(ethscription.ethscriptionNumber),
+
+            // Core metadata
+            contentUriHash: ethscription.contentUriHash,
+            contentSha: ethscription.contentSha,
+            mimetype: ethscription.mimetype,
+            content: includeContent ? _getEthscriptionContent(ethscriptionId) : bytes(""),
+
+            // Ownership
+            currentOwner: _ownerOf(uint256(ethscription.ethscriptionNumber)),
+            creator: ethscription.creator,
+            initialOwner: ethscription.initialOwner,
+            previousOwner: ethscription.previousOwner,
+
+            // Block/time data
+            l1BlockHash: ethscription.l1BlockHash,
+            l1BlockNumber: uint256(ethscription.l1BlockNumber),
+            l2BlockNumber: uint256(ethscription.l2BlockNumber),
+            createdAt: uint256(ethscription.createdAt),
+
+            // Protocol
+            esip6: ethscription.esip6
+        });
     }
 
-    /// @notice Get content for an ethscription
-    function getEthscriptionContent(bytes32 ethscriptionId) public view returns (bytes memory) {
-        Ethscription storage ethscription = _getEthscriptionOrRevert(ethscriptionId);
+    /// @notice Get complete ethscription data (includes content by default)
+    /// @param ethscriptionId The ethscription ID to look up
+    /// @return The complete ethscription data with content
+    function getEthscription(bytes32 ethscriptionId) external view returns (Ethscription memory) {
+        return _buildEthscription(ethscriptionId, true);
+    }
+
+    /// @notice Get complete ethscription data with option to exclude content
+    /// @param ethscriptionId The ethscription ID to look up
+    /// @param includeContent Whether to include content (false for gas efficiency)
+    /// @return The complete ethscription data
+    function getEthscription(bytes32 ethscriptionId, bool includeContent) external view returns (Ethscription memory) {
+        return _buildEthscription(ethscriptionId, includeContent);
+    }
+
+    /// @notice Get complete ethscription data by tokenId (includes content by default)
+    /// @param tokenId The token ID to look up
+    /// @return The complete ethscription data with content
+    function getEthscription(uint256 tokenId) external view returns (Ethscription memory) {
+        bytes32 ethscriptionId = tokenIdToEthscriptionId[tokenId];
+        // _buildEthscription calls _getEthscriptionOrRevert which handles existence check
+        return _buildEthscription(ethscriptionId, true);
+    }
+
+    /// @notice Get complete ethscription data by tokenId with option to exclude content
+    /// @param tokenId The token ID to look up
+    /// @param includeContent Whether to include content (false for gas efficiency)
+    /// @return The complete ethscription data
+    function getEthscription(uint256 tokenId, bool includeContent) external view returns (Ethscription memory) {
+        bytes32 ethscriptionId = tokenIdToEthscriptionId[tokenId];
+        // _buildEthscription calls _getEthscriptionOrRevert which handles existence check
+        return _buildEthscription(ethscriptionId, includeContent);
+    }
+
+    // -------------------- Internal helper for content retrieval --------------------
+
+    /// @notice Internal: Get content for an ethscription
+    /// @dev Kept as internal for tokenURI and other internal uses
+    function _getEthscriptionContent(bytes32 ethscriptionId) internal view returns (bytes memory) {
+        EthscriptionStorage storage ethscription = _getEthscriptionOrRevert(ethscriptionId);
         bytes32 ref = contentStorageBySha[ethscription.contentSha];
 
         // Check if it's inline content using BytePackLib
@@ -385,36 +481,6 @@ contract Ethscriptions is ERC721EthscriptionsSequentialEnumerableUpgradeable {
         address pointer = address(uint160(uint256(ref)));
 
         return SSTORE2Unlimited.read(pointer);
-    }
-
-    /// @notice Get ethscription details and content in a single call
-    /// @param ethscriptionId The ethscription ID to look up
-    /// @return ethscription The ethscription struct
-    /// @return content The content bytes
-    function getEthscriptionWithContent(bytes32 ethscriptionId) external view returns (Ethscription memory ethscription, bytes memory content) {
-        ethscription = _getEthscriptionOrRevert(ethscriptionId);
-        content = getEthscriptionContent(ethscriptionId);
-    }
-
-    /// @notice Overload: get ethscription by tokenId
-    function getEthscription(uint256 tokenId) external view returns (Ethscription memory) {
-        Ethscription storage ethscription = _getEthscriptionOrRevert(tokenId);
-        return ethscription;
-    }
-
-    /// @notice Overload: get content by tokenId
-    function getEthscriptionContent(uint256 tokenId) external view returns (bytes memory) {
-        // Ensure it exists
-        _getEthscriptionOrRevert(tokenId);
-        bytes32 id = tokenIdToEthscriptionId[tokenId];
-        return getEthscriptionContent(id);
-    }
-
-    /// @notice Overload: get struct and content by tokenId
-    function getEthscriptionWithContent(uint256 tokenId) external view returns (Ethscription memory ethscription, bytes memory content) {
-        ethscription = _getEthscriptionOrRevert(tokenId);
-        bytes32 id = tokenIdToEthscriptionId[tokenId];
-        content = getEthscriptionContent(id);
     }
 
     // ---------------- Ownership & Existence Checks ----------------
@@ -433,7 +499,7 @@ contract Ethscriptions is ERC721EthscriptionsSequentialEnumerableUpgradeable {
     /// @notice Get owner of an ethscription by transaction hash
     /// @dev Overload of ownerOf that accepts transaction hash instead of token ID
     function ownerOf(bytes32 ethscriptionId) external view returns (address) {
-        Ethscription storage ethscription = _getEthscriptionOrRevert(ethscriptionId);
+        EthscriptionStorage storage ethscription = _getEthscriptionOrRevert(ethscriptionId);
         uint256 tokenId = ethscription.ethscriptionNumber;
 
         return ownerOf(tokenId);
@@ -443,7 +509,7 @@ contract Ethscriptions is ERC721EthscriptionsSequentialEnumerableUpgradeable {
     /// @param ethscriptionId The ethscription ID to look up
     /// @return The token ID (ethscription number)
     function getTokenId(bytes32 ethscriptionId) external view returns (uint256) {
-        Ethscription storage ethscription = _getEthscriptionOrRevert(ethscriptionId);
+        EthscriptionStorage storage ethscription = _getEthscriptionOrRevert(ethscriptionId);
         return ethscription.ethscriptionNumber;
     }
 
@@ -463,7 +529,7 @@ contract Ethscriptions is ERC721EthscriptionsSequentialEnumerableUpgradeable {
     function _update(address to, uint256 tokenId, address auth) internal virtual override returns (address from) {
         // Find the ethscription ID for this token ID (ethscription number)
         bytes32 id = tokenIdToEthscriptionId[tokenId];
-        Ethscription storage ethscription = ethscriptions[id];
+        EthscriptionStorage storage ethscription = ethscriptions[id];
 
         // Call parent implementation first to handle the actual update
         from = super._update(to, tokenId, auth);
@@ -617,7 +683,7 @@ contract Ethscriptions is ERC721EthscriptionsSequentialEnumerableUpgradeable {
             bytes32 ethscriptionId = pendingGenesisEvents[i];
 
             // Get the ethscription data
-            Ethscription storage ethscription = ethscriptions[ethscriptionId];
+            EthscriptionStorage storage ethscription = ethscriptions[ethscriptionId];
             uint256 tokenId = ethscription.ethscriptionNumber;
 
             // Emit events in the same order as live mints:

--- a/contracts/src/EthscriptionsProver.sol
+++ b/contracts/src/EthscriptionsProver.sol
@@ -136,9 +136,10 @@ contract EthscriptionsProver {
     /// @param ethscriptionId The Ethscription ID (L1 tx hash)
     /// @param proofInfo The queued proof info containing block data
     function _createAndSendProof(bytes32 ethscriptionId, QueuedProof memory proofInfo) internal {
-        // Get ethscription data including previous owner
-        Ethscriptions.Ethscription memory ethscription = ethscriptions.getEthscription(ethscriptionId);
-        address currentOwner = ethscriptions.ownerOf(ethscriptionId);
+        // Get ethscription data including previous owner (without content for gas efficiency)
+        Ethscriptions.Ethscription memory ethscription = ethscriptions.getEthscription(ethscriptionId, false);
+        // currentOwner is already in the struct now
+        address currentOwner = ethscription.currentOwner;
 
         // Create proof struct with all ethscription data
         EthscriptionDataProof memory proof = EthscriptionDataProof({
@@ -150,7 +151,7 @@ contract EthscriptionsProver {
             currentOwner: currentOwner,
             previousOwner: ethscription.previousOwner,
             esip6: ethscription.esip6,
-            ethscriptionNumber: ethscription.ethscriptionNumber,
+            ethscriptionNumber: uint48(ethscription.ethscriptionNumber),
             l1BlockNumber: proofInfo.l1BlockNumber,
             l2BlockNumber: proofInfo.l2BlockNumber,
             l2Timestamp: proofInfo.l2BlockTimestamp

--- a/contracts/src/libraries/EthscriptionsRendererLib.sol
+++ b/contracts/src/libraries/EthscriptionsRendererLib.sol
@@ -15,7 +15,7 @@ library EthscriptionsRendererLib {
     /// @param etsc Storage pointer to the ethscription
     /// @param ethscriptionId The ethscription ID (L1 tx hash)
     /// @return JSON string of attributes array
-    function buildAttributes(Ethscriptions.Ethscription storage etsc, bytes32 ethscriptionId)
+    function buildAttributes(Ethscriptions.EthscriptionStorage storage etsc, bytes32 ethscriptionId)
         internal
         view
         returns (string memory)
@@ -56,7 +56,7 @@ library EthscriptionsRendererLib {
     /// @param content The content bytes
     /// @return mediaType Either "image" or "animation_url"
     /// @return mediaUri The data URI for the media
-    function getMediaUri(Ethscriptions.Ethscription storage etsc, bytes memory content)
+    function getMediaUri(Ethscriptions.EthscriptionStorage storage etsc, bytes memory content)
         internal
         view
         returns (string memory mediaType, string memory mediaUri)
@@ -88,7 +88,7 @@ library EthscriptionsRendererLib {
     /// @param content The content bytes
     /// @return The complete base64-encoded data URI
     function buildTokenURI(
-        Ethscriptions.Ethscription storage etsc,
+        Ethscriptions.EthscriptionStorage storage etsc,
         bytes32 ethscriptionId,
         bytes memory content
     ) internal view returns (string memory) {

--- a/contracts/test/EthscriptionsWithContent.t.sol
+++ b/contracts/test/EthscriptionsWithContent.t.sol
@@ -5,7 +5,7 @@ import "./TestSetup.sol";
 
 contract EthscriptionsWithContentTest is TestSetup {
 
-    function testGetEthscriptionWithContent() public {
+    function testGetEthscription() public {
         // Create a test ethscription first
         bytes32 txHash = bytes32(uint256(12345));
         address creator = address(0x1);
@@ -30,59 +30,93 @@ contract EthscriptionsWithContentTest is TestSetup {
 
         uint256 tokenId = ethscriptions.createEthscription(params);
 
-        // Test the new combined method
-        (Ethscriptions.Ethscription memory ethscription, bytes memory content) = ethscriptions.getEthscriptionWithContent(txHash);
+        // Test the new getEthscription method that returns Ethscription
+        Ethscriptions.Ethscription memory complete = ethscriptions.getEthscription(txHash);
 
         // Verify ethscription data
-        assertEq(ethscription.creator, creator);
-        assertEq(ethscription.initialOwner, initialOwner);
-        assertEq(ethscription.previousOwner, creator);
-        assertEq(ethscription.ethscriptionNumber, tokenId);
-        assertEq(ethscription.mimetype, "text/plain");
-        assertEq(ethscription.esip6, false);
+        assertEq(complete.ethscriptionId, txHash);
+        assertEq(complete.ethscriptionNumber, tokenId);
+        assertEq(complete.creator, creator);
+        assertEq(complete.initialOwner, initialOwner);
+        assertEq(complete.previousOwner, creator);
+        assertEq(complete.currentOwner, initialOwner);
+        assertEq(complete.mimetype, "text/plain");
+        assertEq(complete.esip6, false);
 
         // Verify content
-        assertEq(content, bytes(testContent));
+        assertEq(complete.content, bytes(testContent));
 
-        // Compare with individual method calls to ensure they return the same data
-        Ethscriptions.Ethscription memory ethscriptionSeparate = ethscriptions.getEthscription(txHash);
-        bytes memory contentSeparate = ethscriptions.getEthscriptionContent(txHash);
+        // Test the version without content using the overloaded function
+        Ethscriptions.Ethscription memory withoutContent = ethscriptions.getEthscription(txHash, false);
 
-        // Compare structs (we'll compare individual fields since struct comparison isn't directly supported)
-        assertEq(ethscription.creator, ethscriptionSeparate.creator);
-        assertEq(ethscription.initialOwner, ethscriptionSeparate.initialOwner);
-        assertEq(ethscription.previousOwner, ethscriptionSeparate.previousOwner);
-        assertEq(ethscription.ethscriptionNumber, ethscriptionSeparate.ethscriptionNumber);
-        assertEq(ethscription.createdAt, ethscriptionSeparate.createdAt);
-        assertEq(ethscription.l1BlockNumber, ethscriptionSeparate.l1BlockNumber);
-        assertEq(ethscription.l2BlockNumber, ethscriptionSeparate.l2BlockNumber);
-        assertEq(ethscription.l1BlockHash, ethscriptionSeparate.l1BlockHash);
-
-        // Compare content fields
-        assertEq(ethscription.contentUriHash, ethscriptionSeparate.contentUriHash);
-        assertEq(ethscription.contentSha, ethscriptionSeparate.contentSha);
-        assertEq(ethscription.mimetype, ethscriptionSeparate.mimetype);
-        assertEq(ethscription.esip6, ethscriptionSeparate.esip6);
-
-        // Compare content
-        assertEq(content, contentSeparate);
+        // Verify same metadata but empty content
+        assertEq(withoutContent.ethscriptionId, txHash);
+        assertEq(withoutContent.ethscriptionNumber, tokenId);
+        assertEq(withoutContent.creator, creator);
+        assertEq(withoutContent.currentOwner, initialOwner);
+        assertEq(withoutContent.content.length, 0, "Content should be empty");
     }
 
-    function testGetEthscriptionWithContentNonExistent() public {
+    function testGetEthscriptionByTokenId() public {
+        // Create a test ethscription first
+        bytes32 txHash = bytes32(uint256(67890));
+        address creator = address(0x5);
+        address initialOwner = address(0x6);
+        string memory testContent = "Test by token ID";
+
+        // Create the ethscription
+        vm.prank(creator);
+        Ethscriptions.CreateEthscriptionParams memory params = Ethscriptions.CreateEthscriptionParams({
+            ethscriptionId: txHash,
+            contentUriHash: keccak256(bytes("data:text/plain,Test by token ID")),
+            initialOwner: initialOwner,
+            content: bytes(testContent),
+            mimetype: "text/plain",
+            esip6: true,
+            protocolParams: Ethscriptions.ProtocolParams({
+                protocolName: "",
+                operation: "",
+                data: ""
+            })
+        });
+
+        uint256 tokenId = ethscriptions.createEthscription(params);
+
+        // Test getting by token ID
+        Ethscriptions.Ethscription memory complete = ethscriptions.getEthscription(tokenId);
+
+        // Verify ethscription data
+        assertEq(complete.ethscriptionId, txHash, "Ethscription ID should match");
+        assertEq(complete.ethscriptionNumber, tokenId, "Token ID should match");
+        assertEq(complete.creator, creator);
+        assertEq(complete.currentOwner, initialOwner);
+        assertEq(complete.content, bytes(testContent));
+
+        // Test without content version by token ID using the overloaded function
+        Ethscriptions.Ethscription memory withoutContent = ethscriptions.getEthscription(tokenId, false);
+        assertEq(withoutContent.ethscriptionId, txHash);
+        assertEq(withoutContent.content.length, 0, "Content should be empty");
+    }
+
+    function testGetEthscriptionNonExistent() public {
         bytes32 nonExistentTxHash = bytes32(uint256(99999));
 
         // Should revert with EthscriptionDoesNotExist
         vm.expectRevert(Ethscriptions.EthscriptionDoesNotExist.selector);
-        ethscriptions.getEthscriptionWithContent(nonExistentTxHash);
+        ethscriptions.getEthscription(nonExistentTxHash);
+
+        // Same for without content version using the overloaded function
+        vm.expectRevert(Ethscriptions.EthscriptionDoesNotExist.selector);
+        ethscriptions.getEthscription(nonExistentTxHash, false);
     }
 
-    function testGetEthscriptionWithContentLargeContent() public {
-        // Test with content that requires multiple SSTORE2 chunks
+    function testGetEthscriptionWithLargeContent() public {
+        // Test with content that's large (testing SSTORE2Unlimited)
         bytes32 txHash = bytes32(uint256(54321));
         address creator = address(0x3);
         address initialOwner = address(0x4);
 
-        // Create content larger than CHUNK_SIZE (24575 bytes)
+        // Create content larger than inline storage (>31 bytes)
         bytes memory largeContent = new bytes(30000);
         for (uint256 i = 0; i < 30000; i++) {
             largeContent[i] = bytes1(uint8(i % 256));
@@ -106,15 +140,68 @@ contract EthscriptionsWithContentTest is TestSetup {
 
         ethscriptions.createEthscription(params);
 
-        // Test the combined method with large content
-        (Ethscriptions.Ethscription memory ethscription, bytes memory content) = ethscriptions.getEthscriptionWithContent(txHash);
+        // Test the getEthscription method with large content
+        Ethscriptions.Ethscription memory complete = ethscriptions.getEthscription(txHash);
 
         // Verify content is correct
-        assertEq(content.length, 30000);
-        assertEq(content, largeContent);
+        assertEq(complete.content.length, 30000);
+        assertEq(complete.content, largeContent);
 
         // Verify ethscription data
-        assertEq(ethscription.creator, creator);
-        assertEq(ethscription.initialOwner, initialOwner);
+        assertEq(complete.creator, creator);
+        assertEq(complete.initialOwner, initialOwner);
+        assertEq(complete.currentOwner, initialOwner);
+
+        // Test without content - should have zero-length content using the overloaded function
+        Ethscriptions.Ethscription memory withoutContent = ethscriptions.getEthscription(txHash, false);
+        assertEq(withoutContent.content.length, 0, "Content should be empty");
+        assertEq(withoutContent.creator, creator);
+        assertEq(withoutContent.currentOwner, initialOwner);
+    }
+
+    function testGetEthscriptionWithSmallContent() public {
+        // Test with content that fits inline (≤31 bytes)
+        bytes32 txHash = bytes32(uint256(11111));
+        address creator = address(0x7);
+        address initialOwner = address(0x8);
+
+        // Create small content (10 bytes)
+        bytes memory smallContent = hex"48656c6c6f576f726c64"; // "HelloWorld"
+
+        // Create the ethscription
+        vm.prank(creator);
+        Ethscriptions.CreateEthscriptionParams memory params = Ethscriptions.CreateEthscriptionParams({
+            ethscriptionId: txHash,
+            contentUriHash: keccak256(bytes("data:text/plain,HelloWorld")),
+            initialOwner: initialOwner,
+            content: smallContent,
+            mimetype: "text/plain",
+            esip6: false,
+            protocolParams: Ethscriptions.ProtocolParams({
+                protocolName: "",
+                operation: "",
+                data: ""
+            })
+        });
+
+        uint256 tokenId = ethscriptions.createEthscription(params);
+
+        // Test the getEthscription method with small inline content
+        Ethscriptions.Ethscription memory complete = ethscriptions.getEthscription(txHash);
+
+        // Verify content is correct
+        assertEq(complete.content, smallContent);
+        assertEq(complete.content.length, 10);
+
+        // Verify ownership chain
+        assertEq(complete.creator, creator);
+        assertEq(complete.initialOwner, initialOwner);
+        assertEq(complete.currentOwner, initialOwner);
+        assertEq(complete.previousOwner, creator);
+
+        // Test getting by token ID too
+        Ethscriptions.Ethscription memory byTokenId = ethscriptions.getEthscription(tokenId);
+        assertEq(byTokenId.ethscriptionId, txHash);
+        assertEq(byTokenId.content, smallContent);
     }
 }

--- a/contracts/test/EthscriptionsWithTestFunctions.sol
+++ b/contracts/test/EthscriptionsWithTestFunctions.sol
@@ -14,21 +14,21 @@ contract EthscriptionsWithTestFunctions is Ethscriptions {
     /// @notice Check if content is stored for an ethscription
     /// @dev Test-only function to check if content exists
     function hasContent(bytes32 ethscriptionId) external view returns (bool) {
-        Ethscription storage ethscription = _getEthscriptionOrRevert(ethscriptionId);
+        EthscriptionStorage storage ethscription = _getEthscriptionOrRevert(ethscriptionId);
         return contentStorageBySha[ethscription.contentSha] != bytes32(0);
     }
 
     /// @notice Get the content storage value for an ethscription
     /// @dev Test-only function to inspect storage (either packed bytes or SSTORE2 address)
     function getContentStorage(bytes32 ethscriptionId) external view returns (bytes32) {
-        Ethscription storage ethscription = _getEthscriptionOrRevert(ethscriptionId);
+        EthscriptionStorage storage ethscription = _getEthscriptionOrRevert(ethscriptionId);
         return contentStorageBySha[ethscription.contentSha];
     }
 
     /// @notice Get the content pointer for an ethscription (only for SSTORE2 stored content)
     /// @dev Test-only function to inspect SSTORE2 address
     function getContentPointer(bytes32 ethscriptionId) external view returns (address) {
-        Ethscription storage ethscription = _getEthscriptionOrRevert(ethscriptionId);
+        EthscriptionStorage storage ethscription = _getEthscriptionOrRevert(ethscriptionId);
         bytes32 stored = contentStorageBySha[ethscription.contentSha];
 
         // Check if it's inline content using BytePackLib
@@ -46,6 +46,6 @@ contract EthscriptionsWithTestFunctions is Ethscriptions {
     /// @param ethscriptionId The ethscription ID (L1 tx hash)
     /// @return The content data
     function readContent(bytes32 ethscriptionId) external view returns (bytes memory) {
-        return getEthscriptionContent(ethscriptionId);
+        return _getEthscriptionContent(ethscriptionId);
     }
 }

--- a/contracts/test/SSTORE2ContentSizes.t.sol
+++ b/contracts/test/SSTORE2ContentSizes.t.sol
@@ -130,7 +130,7 @@ contract SSTORE2ContentSizesTest is TestSetup {
         // Test content retrieval via getEthscriptionContent
         g0 = gasleft();
         vm.resumeGasMetering();
-        bytes memory retrievedContent = eth.getEthscriptionContent(txHash);
+        bytes memory retrievedContent = eth.readContent(txHash);
         vm.pauseGasMetering();
         uint256 retrievalGas = g0 - gasleft();
 
@@ -284,8 +284,8 @@ contract SSTORE2ContentSizesTest is TestSetup {
         assertEq(pointer1, pointer2, "Pointers should be identical");
 
         // Verify content retrieval works for both
-        bytes memory content1 = eth.getEthscriptionContent(txHash1);
-        bytes memory content2 = eth.getEthscriptionContent(txHash2);
+        bytes memory content1 = eth.readContent(txHash1);
+        bytes memory content2 = eth.readContent(txHash2);
         assertEq(keccak256(content1), keccak256(content2), "Content should be identical");
         assertEq(keccak256(content1), keccak256(content), "Retrieved content should match original");
 

--- a/lib/storage_reader.rb
+++ b/lib/storage_reader.rb
@@ -15,9 +15,9 @@ class StorageReader
       { 'name' => 'initialOwner', 'type' => 'address' },
       { 'name' => 'previousOwner', 'type' => 'address' },
       { 'name' => 'l1BlockHash', 'type' => 'bytes32' },
-      { 'name' => 'l1BlockNumber', 'type' => 'uint48' },
-      { 'name' => 'l2BlockNumber', 'type' => 'uint48' },
-      { 'name' => 'createdAt', 'type' => 'uint48' },
+      { 'name' => 'l1BlockNumber', 'type' => 'uint256' },
+      { 'name' => 'l2BlockNumber', 'type' => 'uint256' },
+      { 'name' => 'createdAt', 'type' => 'uint256' },
       { 'name' => 'esip6', 'type' => 'bool' }
     ],
     'type' => 'tuple'

--- a/lib/storage_reader.rb
+++ b/lib/storage_reader.rb
@@ -1,8 +1,30 @@
 class StorageReader
   ETHSCRIPTIONS_ADDRESS = SysConfig::ETHSCRIPTIONS_ADDRESS.to_hex
 
-  # Define the flattened Ethscription struct ABI
+  # Define the new denormalized Ethscription struct ABI
   ETHSCRIPTION_STRUCT_ABI = {
+    'components' => [
+      { 'name' => 'ethscriptionId', 'type' => 'bytes32' },
+      { 'name' => 'ethscriptionNumber', 'type' => 'uint256' },
+      { 'name' => 'contentUriHash', 'type' => 'bytes32' },
+      { 'name' => 'contentSha', 'type' => 'bytes32' },
+      { 'name' => 'mimetype', 'type' => 'string' },
+      { 'name' => 'content', 'type' => 'bytes' },
+      { 'name' => 'currentOwner', 'type' => 'address' },
+      { 'name' => 'creator', 'type' => 'address' },
+      { 'name' => 'initialOwner', 'type' => 'address' },
+      { 'name' => 'previousOwner', 'type' => 'address' },
+      { 'name' => 'l1BlockHash', 'type' => 'bytes32' },
+      { 'name' => 'l1BlockNumber', 'type' => 'uint48' },
+      { 'name' => 'l2BlockNumber', 'type' => 'uint48' },
+      { 'name' => 'createdAt', 'type' => 'uint48' },
+      { 'name' => 'esip6', 'type' => 'bool' }
+    ],
+    'type' => 'tuple'
+  }
+
+  # Define the old storage struct ABI for getEthscriptionWithoutContent
+  ETHSCRIPTION_STORAGE_STRUCT_ABI = {
     'components' => [
       { 'name' => 'contentUriHash', 'type' => 'bytes32' },
       { 'name' => 'contentSha', 'type' => 'bytes32' },
@@ -28,6 +50,18 @@ class StorageReader
       'stateMutability' => 'view',
       'inputs' => [
         { 'name' => 'ethscriptionId', 'type' => 'bytes32' }
+      ],
+      'outputs' => [
+        ETHSCRIPTION_STRUCT_ABI
+      ]
+    },
+    {
+      'name' => 'getEthscription',
+      'type' => 'function',
+      'stateMutability' => 'view',
+      'inputs' => [
+        { 'name' => 'ethscriptionId', 'type' => 'bytes32' },
+        { 'name' => 'includeContent', 'type' => 'bool' }
       ],
       'outputs' => [
         ETHSCRIPTION_STRUCT_ABI
@@ -63,28 +97,16 @@ class StorageReader
       'outputs' => [
         { 'name' => '', 'type' => 'uint256' }
       ]
-    },
-    {
-      'name' => 'getEthscriptionWithContent',
-      'type' => 'function',
-      'stateMutability' => 'view',
-      'inputs' => [
-        { 'name' => 'ethscriptionId', 'type' => 'bytes32' }
-      ],
-      'outputs' => [
-        { 'name' => 'ethscription', **ETHSCRIPTION_STRUCT_ABI },
-        { 'name' => 'content', 'type' => 'bytes' }
-      ]
     }
   ]
 
   class << self
     def get_ethscription_with_content(tx_hash, block_tag: 'latest')
-      # Single call to get both ethscription and content
+      # Use the new getEthscription function that returns everything including content
       tx_hash_bytes32 = format_bytes32(tx_hash)
 
       # Build function signature and encode parameters
-      function_sig = Eth::Util.keccak256('getEthscriptionWithContent(bytes32)')[0...4]
+      function_sig = Eth::Util.keccak256('getEthscription(bytes32)')[0...4]
 
       # Encode the parameter (bytes32 is already 32 bytes)
       calldata = function_sig + [tx_hash_bytes32].pack('H*')
@@ -97,33 +119,41 @@ class StorageReader
       # If result is nil, that's an RPC/network error
       raise StandardError, "RPC call failed for ethscription #{tx_hash}" if result.nil?
 
-      # Decode the tuple: (Ethscription, bytes)
-      types = ['(bytes32,bytes32,bytes32,address,uint48,uint48,string,address,uint48,bool,address,uint48)', 'bytes']
+      # Decode the single Ethscription struct with all fields including content
+      # New struct order: ethscriptionId, ethscriptionNumber, contentUriHash, contentSha, mimetype, content,
+      #                   currentOwner, creator, initialOwner, previousOwner, l1BlockHash,
+      #                   l1BlockNumber, l2BlockNumber, createdAt, esip6
+      types = ['(bytes32,uint256,bytes32,bytes32,string,bytes,address,address,address,address,bytes32,uint256,uint256,uint256,bool)']
       decoded = Eth::Abi.decode(types, result)
 
-      # Extract ethscription struct and content
+      # The struct is returned as an array
       ethscription_data = decoded[0]
-      content_data = decoded[1]
 
       {
+        # Identity
+        ethscription_id: '0x' + ethscription_data[0].unpack1('H*'),
+        ethscription_number: ethscription_data[1],
+
         # Content fields
-        content_uri_hash: '0x' + ethscription_data[0].unpack1('H*'),
-        content_sha: '0x' + ethscription_data[1].unpack1('H*'),
-        mimetype: ethscription_data[6],  # mimetype at index 6
-        esip6: ethscription_data[9],  # bool at index 9
+        content_uri_hash: '0x' + ethscription_data[2].unpack1('H*'),
+        content_sha: '0x' + ethscription_data[3].unpack1('H*'),
+        mimetype: ethscription_data[4],
+        content: ethscription_data[5],  # content is now at index 5
 
-        # Main fields
-        creator: Eth::Address.new(ethscription_data[3]).to_s,
-        initial_owner: Eth::Address.new(ethscription_data[7]).to_s,
-        previous_owner: Eth::Address.new(ethscription_data[10]).to_s,
-        ethscription_number: ethscription_data[8],
-        created_at: ethscription_data[4],
-        l1_block_number: ethscription_data[5],
-        l2_block_number: ethscription_data[11],
-        l1_block_hash: '0x' + ethscription_data[2].unpack1('H*'),
+        # Ownership fields
+        current_owner: Eth::Address.new(ethscription_data[6]).to_s,
+        creator: Eth::Address.new(ethscription_data[7]).to_s,
+        initial_owner: Eth::Address.new(ethscription_data[8]).to_s,
+        previous_owner: Eth::Address.new(ethscription_data[9]).to_s,
 
-        # Content
-        content: content_data
+        # Block/time data
+        l1_block_hash: '0x' + ethscription_data[10].unpack1('H*'),
+        l1_block_number: ethscription_data[11],
+        l2_block_number: ethscription_data[12],
+        created_at: ethscription_data[13],
+
+        # Protocol
+        esip6: ethscription_data[14]
       }
     rescue => e
       Rails.logger.error "Failed to get ethscription with content #{tx_hash}: #{e.message}"
@@ -132,14 +162,15 @@ class StorageReader
     end
 
     def get_ethscription(tx_hash, block_tag: 'latest')
-      # Ensure tx_hash is properly formatted as bytes32
+      # Use getEthscription with includeContent=false for gas-optimized queries without content
       tx_hash_bytes32 = format_bytes32(tx_hash)
 
       # Build function signature and encode parameters
-      function_sig = Eth::Util.keccak256('getEthscription(bytes32)')[0...4]
+      function_sig = Eth::Util.keccak256('getEthscription(bytes32,bool)')[0...4]
 
-      # Encode the parameter (bytes32 is already 32 bytes)
-      calldata = function_sig + [tx_hash_bytes32].pack('H*')
+      # Encode the parameters: bytes32 and bool (false)
+      # bytes32 (32 bytes) + bool padded to 32 bytes (0x00...00 for false)
+      calldata = function_sig + [tx_hash_bytes32].pack('H*') + '0' * 64  # false as 32 bytes of zeros
 
       # Make the eth_call
       result = eth_call('0x' + calldata.unpack1('H*'), block_tag)
@@ -148,29 +179,41 @@ class StorageReader
       # Nil indicates an RPC/network failure
       raise StandardError, "RPC call failed for ethscription #{tx_hash}" if result.nil?
 
-      # Decode using Eth::Abi - flattened struct
-      types = ['(bytes32,bytes32,bytes32,address,uint48,uint48,string,address,uint48,bool,address,uint48)']
+      # Decode the Ethscription struct without content
+      # Struct order: ethscriptionId, ethscriptionNumber, contentUriHash, contentSha, mimetype, content (empty),
+      #               currentOwner, creator, initialOwner, previousOwner, l1BlockHash,
+      #               l1BlockNumber, l2BlockNumber, createdAt, esip6
+      types = ['(bytes32,uint256,bytes32,bytes32,string,bytes,address,address,address,address,bytes32,uint256,uint256,uint256,bool)']
       decoded = Eth::Abi.decode(types, result)
 
       # The struct is returned as an array
       ethscription_data = decoded[0]
 
       {
-        # Content fields
-        content_uri_hash: '0x' + ethscription_data[0].unpack1('H*'),
-        content_sha: '0x' + ethscription_data[1].unpack1('H*'),
-        mimetype: ethscription_data[6],  # mimetype at index 6
-        esip6: ethscription_data[9],  # bool at index 9
+        # Identity
+        ethscription_id: '0x' + ethscription_data[0].unpack1('H*'),
+        ethscription_number: ethscription_data[1],
 
-        # Main fields
-        creator: Eth::Address.new(ethscription_data[3]).to_s,
-        initial_owner: Eth::Address.new(ethscription_data[7]).to_s,
-        previous_owner: Eth::Address.new(ethscription_data[10]).to_s,
-        ethscription_number: ethscription_data[8],
-        created_at: ethscription_data[4],
-        l1_block_number: ethscription_data[5],
-        l2_block_number: ethscription_data[11],
-        l1_block_hash: '0x' + ethscription_data[2].unpack1('H*')
+        # Content fields (no actual content bytes)
+        content_uri_hash: '0x' + ethscription_data[2].unpack1('H*'),
+        content_sha: '0x' + ethscription_data[3].unpack1('H*'),
+        mimetype: ethscription_data[4],
+        # Skip content at index 5 (it's empty for WithoutContent)
+
+        # Ownership fields
+        current_owner: Eth::Address.new(ethscription_data[6]).to_s,
+        creator: Eth::Address.new(ethscription_data[7]).to_s,
+        initial_owner: Eth::Address.new(ethscription_data[8]).to_s,
+        previous_owner: Eth::Address.new(ethscription_data[9]).to_s,
+
+        # Block/time data
+        l1_block_hash: '0x' + ethscription_data[10].unpack1('H*'),
+        l1_block_number: ethscription_data[11],
+        l2_block_number: ethscription_data[12],
+        created_at: ethscription_data[13],
+
+        # Protocol
+        esip6: ethscription_data[14]
       }
     rescue EthRpcClient::ExecutionRevertedError => e
       # Contract reverted - ethscription doesn't exist


### PR DESCRIPTION
- Renamed the Ethscription struct to EthscriptionStorage for optimized storage.
- Introduced a new Ethscription struct for external use, containing all relevant fields.
- Updated mapping and retrieval functions to accommodate the new struct design.
- Enhanced getEthscription methods to allow optional content inclusion for gas efficiency.
- Adjusted tests to reflect changes in struct usage and retrieval methods.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduce `EthscriptionStorage` for on-chain storage, a new denormalized `Ethscription` for external use, and overloaded `getEthscription` methods with optional content; update renderer, prover, tests, genesis script, and Ruby client accordingly.
> 
> - **Core (contracts/src/Ethscriptions.sol)**
>   - Split structs: on-chain `EthscriptionStorage` vs external `Ethscription` (denormalized with owner/content).
>   - Update mapping to `mapping(bytes32 => EthscriptionStorage)` and all internal references.
>   - Add `_buildEthscription` and overload `getEthscription` by ID/tokenId with `includeContent` flag; default includes content.
>   - Replace public content getter with internal `_getEthscriptionContent`; update `tokenURI`, `getMediaUri`, ownership/lookup helpers accordingly.
> - **Renderer (libraries/EthscriptionsRendererLib.sol)**
>   - Change library funcs to accept `EthscriptionStorage` and adapt attribute/media building.
> - **Prover (EthscriptionsProver.sol)**
>   - Use `getEthscription(id, false)` and read `currentOwner` from returned struct; cast `ethscriptionNumber` to `uint48`.
> - **Genesis Script (contracts/script/L2Genesis.s.sol)**
>   - Write genesis entries using `EthscriptionStorage`.
> - **Tests**
>   - Replace content/struct access with new `getEthscription` variants; add tests for with/without content and by tokenId.
>   - Introduce helper `readContent` via test contract; update SSTORE2 tests accordingly.
> - **Ruby Client (lib/storage_reader.rb)**
>   - Update ABI to new `Ethscription` tuple and overloaded `getEthscription(bytes32,bool)`; decode fields including `currentOwner` and optional `content`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7b46837a35c8d7e89f36ff154108b43ff71fe21f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->