### PR TITLE
Refactor ERC721 Ethscriptions Collection and Manager Contracts

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -16,7 +16,7 @@ GIT
 
 GIT
   remote: https://github.com/0xfacet/facet_rails_common.git
-  revision: e733e3877d835f68e8671d12d6ef9c0d24025af4
+  revision: 05f6ce2b3b67de2bd8aef0151f985273f8074d05
   branch: lenient_base64
   specs:
     facet_rails_common (0.1.0)

--- a/contracts/src/ERC721EthscriptionsCollection.sol
+++ b/contracts/src/ERC721EthscriptionsCollection.sol
@@ -17,8 +17,8 @@ contract ERC721EthscriptionsCollection is ERC721EthscriptionsEnumerableUpgradeab
 
     Ethscriptions public constant ethscriptions = Ethscriptions(Predeploys.ETHSCRIPTIONS);
 
-    /// @notice Factory (manager) that deployed this contract
-    address public factory;
+    /// @notice Manager contract that deployed and controls this collection
+    ERC721EthscriptionsCollectionManager public manager;
 
     // Events
     event MemberAdded(bytes32 indexed ethscriptionId, uint256 indexed tokenId);
@@ -30,7 +30,7 @@ contract ERC721EthscriptionsCollection is ERC721EthscriptionsEnumerableUpgradeab
     error TransferNotAllowed();
 
     modifier onlyFactory() {
-        if (msg.sender != factory) revert NotFactory();
+        if (msg.sender != address(manager)) revert NotFactory();
         _;
     }
 
@@ -41,12 +41,11 @@ contract ERC721EthscriptionsCollection is ERC721EthscriptionsEnumerableUpgradeab
     ) external initializer {
         __ERC721_init(name_, symbol_);
         __Ownable_init(initialOwner_);
-        factory = msg.sender;
+        manager = ERC721EthscriptionsCollectionManager(msg.sender);
     }
 
-    /// @notice Lookup collection id via the factory registry
+    /// @notice Lookup collection id via the manager registry
     function collectionId() public view returns (bytes32) {
-        ERC721EthscriptionsCollectionManager manager = ERC721EthscriptionsCollectionManager(factory);
         bytes32 id = manager.collectionIdForAddress(address(this));
         if (id == bytes32(0)) revert UnknownCollection();
         return id;
@@ -89,7 +88,6 @@ contract ERC721EthscriptionsCollection is ERC721EthscriptionsEnumerableUpgradeab
     {
         if (!_tokenExists(tokenId)) revert("Token does not exist");
 
-        ERC721EthscriptionsCollectionManager manager = ERC721EthscriptionsCollectionManager(factory);
         ERC721EthscriptionsCollectionManager.CollectionItem memory item =
             manager.getCollectionItem(collectionId(), tokenId);
         if (item.ethscriptionId == bytes32(0)) revert("Token not in collection");
@@ -141,6 +139,25 @@ contract ERC721EthscriptionsCollection is ERC721EthscriptionsEnumerableUpgradeab
         override(ERC721EthscriptionsUpgradeable, IERC721)
     {
         revert TransferNotAllowed();
+    }
+
+    /// @notice OpenSea collection-level metadata
+    /// @return JSON string with collection metadata
+    function contractURI() external view returns (string memory) {
+        ERC721EthscriptionsCollectionManager.CollectionMetadata memory metadata =
+            manager.getCollectionByAddress(address(this));
+
+        // Build JSON with OpenSea fields
+        string memory json = string.concat(
+            '{"name":"', metadata.name.escapeJSON(),
+            '","description":"', metadata.description.escapeJSON(),
+            '","image":"', metadata.logoImageUri.escapeJSON(),
+            '","banner_image":"', metadata.bannerImageUri.escapeJSON(),
+            '","external_link":"', metadata.websiteLink.escapeJSON(),
+            '"}'
+        );
+
+        return json;
     }
 
     function safeTransferFrom(address, address, uint256, bytes memory)

--- a/contracts/src/ERC721EthscriptionsCollectionManager.sol
+++ b/contracts/src/ERC721EthscriptionsCollectionManager.sol
@@ -3,13 +3,17 @@ pragma solidity 0.8.24;
 
 import "@openzeppelin/contracts/utils/Create2.sol";
 import "@openzeppelin/contracts/utils/cryptography/MerkleProof.sol";
+import {LibString} from "solady/utils/LibString.sol";
 import "./ERC721EthscriptionsCollection.sol";
 import "./libraries/Proxy.sol";
+import "./libraries/DedupedBlobStore.sol";
 import "./Ethscriptions.sol";
 import "./libraries/Predeploys.sol";
 import "./interfaces/IProtocolHandler.sol";
 
 contract ERC721EthscriptionsCollectionManager is IProtocolHandler {
+    using LibString for *;
+
     struct Attribute {
         string traitType;
         string value;
@@ -30,6 +34,23 @@ contract ERC721EthscriptionsCollectionManager is IProtocolHandler {
     }
 
     struct CollectionRecord {
+        address collectionContract;
+        bool locked;
+        bytes32 nameRef;                // DedupedBlobStore reference
+        bytes32 symbolRef;              // DedupedBlobStore reference
+        uint256 maxSupply;
+        bytes32 descriptionRef;         // DedupedBlobStore reference
+        bytes32 logoImageRef;           // DedupedBlobStore reference
+        bytes32 bannerImageRef;         // DedupedBlobStore reference
+        bytes32 backgroundColorRef;     // DedupedBlobStore reference
+        bytes32 websiteLinkRef;         // DedupedBlobStore reference
+        bytes32 twitterLinkRef;         // DedupedBlobStore reference
+        bytes32 discordLinkRef;         // DedupedBlobStore reference
+        bytes32 merkleRoot;
+    }
+
+    /// @notice View struct for external consumption with decoded strings
+    struct CollectionMetadata {
         address collectionContract;
         bool locked;
         string name;
@@ -108,10 +129,13 @@ contract ERC721EthscriptionsCollectionManager is IProtocolHandler {
     Ethscriptions public constant ethscriptions = Ethscriptions(Predeploys.ETHSCRIPTIONS);
     string public constant protocolName = "erc-721-ethscriptions-collection";
 
-    mapping(bytes32 => CollectionRecord) private collectionStore;
-    mapping(bytes32 => mapping(uint256 => CollectionItem)) public collectionItems;
+    mapping(bytes32 => CollectionRecord) internal collectionStore;
+    mapping(bytes32 => mapping(uint256 => CollectionItem)) internal collectionItems;
     mapping(bytes32 => Membership) public membershipOfEthscription;
-    mapping(address => bytes32) private collectionAddressToId;
+    mapping(address => bytes32) internal collectionAddressToId;
+
+    /// @dev Deduplicated storage for collection string fields (name, description, URIs, etc.)
+    mapping(bytes32 => bytes32) internal collectionBlobStorage;
 
     bytes32[] public collectionIds;
 
@@ -195,13 +219,14 @@ contract ERC721EthscriptionsCollectionManager is IProtocolHandler {
         require(!collection.locked, "Collection is locked");
         _requireCollectionOwner(ethscriptionId, editOp.collectionId, "Only collection owner can edit");
 
-        if (bytes(editOp.description).length > 0) collection.description = editOp.description;
-        if (bytes(editOp.logoImageUri).length > 0) collection.logoImageUri = editOp.logoImageUri;
-        if (bytes(editOp.bannerImageUri).length > 0) collection.bannerImageUri = editOp.bannerImageUri;
-        if (bytes(editOp.backgroundColor).length > 0) collection.backgroundColor = editOp.backgroundColor;
-        if (bytes(editOp.websiteLink).length > 0) collection.websiteLink = editOp.websiteLink;
-        if (bytes(editOp.twitterLink).length > 0) collection.twitterLink = editOp.twitterLink;
-        if (bytes(editOp.discordLink).length > 0) collection.discordLink = editOp.discordLink;
+        // Update fields (empty strings allowed to clear fields)
+        (, collection.descriptionRef) = DedupedBlobStore.storeMemory(bytes(editOp.description), collectionBlobStorage);
+        (, collection.logoImageRef) = DedupedBlobStore.storeMemory(bytes(editOp.logoImageUri), collectionBlobStorage);
+        (, collection.bannerImageRef) = DedupedBlobStore.storeMemory(bytes(editOp.bannerImageUri), collectionBlobStorage);
+        (, collection.backgroundColorRef) = DedupedBlobStore.storeMemory(bytes(editOp.backgroundColor), collectionBlobStorage);
+        (, collection.websiteLinkRef) = DedupedBlobStore.storeMemory(bytes(editOp.websiteLink), collectionBlobStorage);
+        (, collection.twitterLinkRef) = DedupedBlobStore.storeMemory(bytes(editOp.twitterLink), collectionBlobStorage);
+        (, collection.discordLinkRef) = DedupedBlobStore.storeMemory(bytes(editOp.discordLink), collectionBlobStorage);
         collection.merkleRoot = editOp.merkleRoot;
 
         emit CollectionEdited(editOp.collectionId);
@@ -263,8 +288,25 @@ contract ERC721EthscriptionsCollectionManager is IProtocolHandler {
         return collectionStore[collectionId].collectionContract;
     }
 
-    function getCollection(bytes32 collectionId) external view returns (CollectionRecord memory) {
-        return collectionStore[collectionId];
+    function getCollection(bytes32 collectionId) public view returns (CollectionMetadata memory) {
+        CollectionRecord storage record = collectionStore[collectionId];
+        require(record.collectionContract != address(0), "Collection does not exist");
+
+        return CollectionMetadata({
+            collectionContract: record.collectionContract,
+            locked: record.locked,
+            name: DedupedBlobStore.readString(record.nameRef),
+            symbol: DedupedBlobStore.readString(record.symbolRef),
+            maxSupply: record.maxSupply,
+            description: DedupedBlobStore.readString(record.descriptionRef),
+            logoImageUri: DedupedBlobStore.readString(record.logoImageRef),
+            bannerImageUri: DedupedBlobStore.readString(record.bannerImageRef),
+            backgroundColor: DedupedBlobStore.readString(record.backgroundColorRef),
+            websiteLink: DedupedBlobStore.readString(record.websiteLinkRef),
+            twitterLink: DedupedBlobStore.readString(record.twitterLinkRef),
+            discordLink: DedupedBlobStore.readString(record.discordLinkRef),
+            merkleRoot: record.merkleRoot
+        });
     }
 
     function getCollectionItem(bytes32 collectionId, uint256 itemIndex) external view returns (CollectionItem memory) {
@@ -300,29 +342,40 @@ contract ERC721EthscriptionsCollectionManager is IProtocolHandler {
         require(!collectionExists(collectionId), "Collection already exists");
 
         Proxy collectionProxy = new Proxy{salt: collectionId}(address(this));
-        bytes memory initCalldata = abi.encodeWithSelector(
+        
+        collectionProxy.upgradeToAndCall(collectionsImplementation, abi.encodeWithSelector(
             ERC721EthscriptionsCollection.initialize.selector,
             metadata.name,
             metadata.symbol,
             ethscriptions.ownerOf(collectionId)
-        );
+        ));
         
-        collectionProxy.upgradeToAndCall(collectionsImplementation, initCalldata);
         collectionProxy.changeAdmin(Predeploys.PROXY_ADMIN);
+
+        // Store string fields using DedupedBlobStore
+        (, bytes32 nameRef) = DedupedBlobStore.storeMemory(bytes(metadata.name), collectionBlobStorage);
+        (, bytes32 symbolRef) = DedupedBlobStore.storeMemory(bytes(metadata.symbol), collectionBlobStorage);
+        (, bytes32 descriptionRef) = DedupedBlobStore.storeMemory(bytes(metadata.description), collectionBlobStorage);
+        (, bytes32 logoImageRef) = DedupedBlobStore.storeMemory(bytes(metadata.logoImageUri), collectionBlobStorage);
+        (, bytes32 bannerImageRef) = DedupedBlobStore.storeMemory(bytes(metadata.bannerImageUri), collectionBlobStorage);
+        (, bytes32 backgroundColorRef) = DedupedBlobStore.storeMemory(bytes(metadata.backgroundColor), collectionBlobStorage);
+        (, bytes32 websiteLinkRef) = DedupedBlobStore.storeMemory(bytes(metadata.websiteLink), collectionBlobStorage);
+        (, bytes32 twitterLinkRef) = DedupedBlobStore.storeMemory(bytes(metadata.twitterLink), collectionBlobStorage);
+        (, bytes32 discordLinkRef) = DedupedBlobStore.storeMemory(bytes(metadata.discordLink), collectionBlobStorage);
 
         collectionStore[collectionId] = CollectionRecord({
             collectionContract: address(collectionProxy),
             locked: false,
-            name: metadata.name,
-            symbol: metadata.symbol,
+            nameRef: nameRef,
+            symbolRef: symbolRef,
             maxSupply: metadata.maxSupply,
-            description: metadata.description,
-            logoImageUri: metadata.logoImageUri,
-            bannerImageUri: metadata.bannerImageUri,
-            backgroundColor: metadata.backgroundColor,
-            websiteLink: metadata.websiteLink,
-            twitterLink: metadata.twitterLink,
-            discordLink: metadata.discordLink,
+            descriptionRef: descriptionRef,
+            logoImageRef: logoImageRef,
+            bannerImageRef: bannerImageRef,
+            backgroundColorRef: backgroundColorRef,
+            websiteLinkRef: websiteLinkRef,
+            twitterLinkRef: twitterLinkRef,
+            discordLinkRef: discordLinkRef,
             merkleRoot: metadata.merkleRoot
         });
         
@@ -406,4 +459,18 @@ contract ERC721EthscriptionsCollectionManager is IProtocolHandler {
     function _inImportMode() private view returns (bool) {
         return block.timestamp < Constants.historicalBackfillApproxDoneAt;
     }
+    
+    function getMembershipOfEthscription(bytes32 ethscriptionId) external view returns (Membership memory) {
+        return membershipOfEthscription[ethscriptionId];
+    }
+    
+    /// @notice Get collection metadata by address
+    /// @param collectionAddress The collection contract address
+    /// @return metadata The collection metadata with decoded strings
+    function getCollectionByAddress(address collectionAddress) external view returns (CollectionMetadata memory) {
+        bytes32 collectionId = collectionAddressToId[collectionAddress];
+        require(collectionId != bytes32(0), "Collection not found");
+        return getCollection(collectionId);
+    }
 }
+

--- a/contracts/src/Ethscriptions.sol
+++ b/contracts/src/Ethscriptions.sol
@@ -126,10 +126,10 @@ contract Ethscriptions is ERC721EthscriptionsSequentialEnumerableUpgradeable {
     mapping(bytes32 => EthscriptionStorage) internal ethscriptions;
 
     /// @dev Content hash (keccak256) => packed content (for <32 bytes) or SSTORE2 pointer (for >=32 bytes)
-    mapping(bytes32 => bytes32) public contentStorage;
+    mapping(bytes32 => bytes32) internal contentStorage;
 
     /// @dev Metadata blob hash (keccak256) => packed metadata or SSTORE2 pointer (for deduplicated metadata storage)
-    mapping(bytes32 => bytes32) public metadataStorage;
+    mapping(bytes32 => bytes32) internal metadataStorage;
 
     /// @dev Content URI hash => first ethscription tx hash that used it (for protocol uniqueness check)
     /// @dev bytes32(0) means unused, non-zero means the content URI has been used

--- a/contracts/src/libraries/DedupedBlobStore.sol
+++ b/contracts/src/libraries/DedupedBlobStore.sol
@@ -92,6 +92,14 @@ library DedupedBlobStore {
         return SSTORE2Unlimited.read(pointer);
     }
 
+    /// @notice Read blob from storage reference and convert to string
+    /// @dev Convenience wrapper to avoid repetitive string() casting
+    /// @param ref The storage reference (packed or SSTORE2 pointer)
+    /// @return str The retrieved data as string
+    function readString(bytes32 ref) internal view returns (string memory) {
+        return string(read(ref));
+    }
+
     /// @notice Read blob from storage mapping by hash
     /// @dev Looks up reference in mapping, then reads
     /// @param hash The hash key

--- a/contracts/test/AddressPrediction.t.sol
+++ b/contracts/test/AddressPrediction.t.sol
@@ -85,7 +85,7 @@ contract AddressPredictionTest is TestSetup {
         collectionsHandler.op_create_collection(collectionId, abi.encode(metadata));
 
         // Assert deployed matches predicted
-        ERC721EthscriptionsCollectionManager.CollectionRecord memory collection =
+        ERC721EthscriptionsCollectionManager.CollectionMetadata memory collection =
             collectionsHandler.getCollection(collectionId);
         address actual = collection.collectionContract;
         assertEq(actual, predicted, "Predicted collection address should match actual deployed proxy");

--- a/contracts/test/CollectionsManager.t.sol
+++ b/contracts/test/CollectionsManager.t.sol
@@ -68,7 +68,7 @@ contract ERC721EthscriptionsCollectionManagerTest is TestSetup {
         // Collection owner is tracked through the original ethscription ownership
 
         // Verify metadata was stored
-        ERC721EthscriptionsCollectionManager.CollectionRecord memory stored = collectionsHandler.getCollection(COLLECTION_TX_HASH);
+        ERC721EthscriptionsCollectionManager.CollectionMetadata memory stored = collectionsHandler.getCollection(COLLECTION_TX_HASH);
         assertEq(stored.name, "Test Collection");
         assertEq(stored.symbol, "TEST");
         assertEq(stored.maxSupply, 100);

--- a/contracts/test/CollectionsProtocol.t.sol
+++ b/contracts/test/CollectionsProtocol.t.sol
@@ -58,7 +58,7 @@ contract CollectionsProtocolTest is TestSetup {
         bytes32 collectionId = txHash;
 
         // Use the getter functions instead of direct mapping access
-        ERC721EthscriptionsCollectionManager.CollectionRecord memory collection = collectionsHandler.getCollection(collectionId);
+        ERC721EthscriptionsCollectionManager.CollectionMetadata memory collection = collectionsHandler.getCollection(collectionId);
         assertNotEq(collection.collectionContract, address(0), "Collection contract should be deployed");
         assertEq(collection.locked, false, "Should not be locked");
 
@@ -66,7 +66,7 @@ contract CollectionsProtocolTest is TestSetup {
         assertEq(collectionContract.totalSupply(), 0, "Initial size should be 0");
 
         // Verify metadata
-        ERC721EthscriptionsCollectionManager.CollectionRecord memory stored = collectionsHandler.getCollection(collectionId);
+        ERC721EthscriptionsCollectionManager.CollectionMetadata memory stored = collectionsHandler.getCollection(collectionId);
         assertEq(stored.name, "Test Collection", "Name should match");
         assertEq(stored.symbol, "TEST", "Symbol should match");
         assertEq(stored.maxSupply, 100, "Max supply should match");
@@ -121,7 +121,7 @@ contract CollectionsProtocolTest is TestSetup {
         bytes32 collectionId = txHash;
 
         // Read back the state
-        ERC721EthscriptionsCollectionManager.CollectionRecord memory collection = collectionsHandler.getCollection(collectionId);
+        ERC721EthscriptionsCollectionManager.CollectionMetadata memory collection = collectionsHandler.getCollection(collectionId);
 
         console.log("Collection exists:", collection.collectionContract != address(0));
         console.log("Collection contract:", collection.collectionContract);
@@ -134,7 +134,7 @@ contract CollectionsProtocolTest is TestSetup {
         assertEq(collectionContract.totalSupply(), 0);
 
         // Read metadata
-        ERC721EthscriptionsCollectionManager.CollectionRecord memory stored = collectionsHandler.getCollection(collectionId);
+        ERC721EthscriptionsCollectionManager.CollectionMetadata memory stored = collectionsHandler.getCollection(collectionId);
         assertEq(stored.name, "Test NFTs");
         assertEq(stored.symbol, "TEST");
         assertEq(stored.maxSupply, 100);
@@ -200,7 +200,7 @@ contract CollectionsProtocolTest is TestSetup {
         console.logBytes(result);
 
         // Decode the result
-        ERC721EthscriptionsCollectionManager.CollectionRecord memory collection = abi.decode(result, (ERC721EthscriptionsCollectionManager.CollectionRecord));
+        ERC721EthscriptionsCollectionManager.CollectionMetadata memory collection = abi.decode(result, (ERC721EthscriptionsCollectionManager.CollectionMetadata));
 
         assertTrue(collection.collectionContract != address(0), "Should have collection contract");
         assertEq(collection.locked, false);


### PR DESCRIPTION
- Updated the `ERC721EthscriptionsCollection` to replace the `factory` address with a `manager` contract for improved control and management.
- Enhanced the `ERC721EthscriptionsCollectionManager` to utilize a deduplicated storage approach for string fields, optimizing metadata handling.
- Introduced new functions for retrieving collection metadata and membership details, improving data accessibility.
- Adjusted tests to reflect changes in data structures and ensure accurate validation of collection metadata retrieval.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switch collection to a typed manager, add collection-level `contractURI`, refactor manager to deduplicate string metadata with new view getters, and update tests accordingly.
> 
> - **Contracts**
>   - **`ERC721EthscriptionsCollection`**:
>     - Replace `factory` address with `manager` (`ERC721EthscriptionsCollectionManager`) and update access control/lookups.
>     - Add `contractURI()` returning OpenSea-style collection JSON.
>     - Simplify `tokenURI` to use `manager` directly.
>   - **`ERC721EthscriptionsCollectionManager`**:
>     - Introduce deduplicated string storage via `DedupedBlobStore`; `CollectionRecord` now stores `bytes32` refs; add `CollectionMetadata` view struct.
>     - `getCollection(bytes32)` now returns `CollectionMetadata`; add `getCollectionByAddress(address)` and `getMembershipOfEthscription(bytes32)`.
>     - Store string fields on creation/edit; make internal mappings `internal`; minor initialization cleanup.
>   - **`Ethscriptions`**:
>     - Restrict `contentStorage`/`metadataStorage` visibility to `internal`.
>   - **Library**:
>     - `DedupedBlobStore`: add `readString(bytes32)` helper.
> - **Tests**
>   - Update to consume `CollectionMetadata` getters and new manager API; adjust address prediction and protocol tests accordingly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f7f09970b402ee356193efbbf9437969ac103605. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->