### PR TITLE
Enhance Ethscriptions Metadata Handling and URI Resolution

### DIFF
--- a/contracts/script/L2Genesis.s.sol
+++ b/contracts/script/L2Genesis.s.sol
@@ -224,10 +224,10 @@ contract L2Genesis is Script {
         _setImplementationCodeNamed(Predeploys.ERC20_FIXED_DENOMINATION_MANAGER, "ERC20FixedDenominationManager");
         _setImplementationCodeNamed(Predeploys.ERC721_ETHSCRIPTIONS_COLLECTION_MANAGER, "ERC721EthscriptionsCollectionManager");
         _setImplementationCodeNamed(Predeploys.ETHSCRIPTIONS_PROVER, "EthscriptionsProver");
-        // Templates and direct deploys live directly at their addresses (no proxy wrapping)
+        _setImplementationCodeNamed(Predeploys.NAME_REGISTRY, "NameRegistry");
+        // Templates live directly at their addresses (no proxy wrapping)
         _setCodeAt(Predeploys.ERC20_FIXED_DENOMINATION_IMPLEMENTATION, "ERC20FixedDenomination");
         _setCodeAt(Predeploys.ERC721_ETHSCRIPTIONS_COLLECTION_IMPLEMENTATION, "ERC721EthscriptionsCollection");
-        _setCodeAt(Predeploys.NAME_REGISTRY, "NameRegistry");
 
         // Create genesis Ethscriptions (writes via proxy to proxy storage)
         createGenesisEthscriptions();

--- a/contracts/script/L2Genesis.s.sol
+++ b/contracts/script/L2Genesis.s.sol
@@ -212,7 +212,8 @@ contract L2Genesis is Script {
             bool isProxiedContract = addr == Predeploys.ETHSCRIPTIONS ||
                 addr == Predeploys.ERC20_FIXED_DENOMINATION_MANAGER ||
                 addr == Predeploys.ETHSCRIPTIONS_PROVER ||
-                addr == Predeploys.ERC721_ETHSCRIPTIONS_COLLECTION_MANAGER;
+                addr == Predeploys.ERC721_ETHSCRIPTIONS_COLLECTION_MANAGER ||
+                addr == Predeploys.NAME_REGISTRY;
             if (isProxiedContract) {
                 address impl = Predeploys.predeployToCodeNamespace(addr);
                 setImplementation(addr, impl);
@@ -223,7 +224,7 @@ contract L2Genesis is Script {
         _setImplementationCodeNamed(Predeploys.ERC20_FIXED_DENOMINATION_MANAGER, "ERC20FixedDenominationManager");
         _setImplementationCodeNamed(Predeploys.ERC721_ETHSCRIPTIONS_COLLECTION_MANAGER, "ERC721EthscriptionsCollectionManager");
         _setImplementationCodeNamed(Predeploys.ETHSCRIPTIONS_PROVER, "EthscriptionsProver");
-        // Templates live directly at their implementation addresses (no proxy wrapping)
+        // Templates and direct deploys live directly at their addresses (no proxy wrapping)
         _setCodeAt(Predeploys.ERC20_FIXED_DENOMINATION_IMPLEMENTATION, "ERC20FixedDenomination");
         _setCodeAt(Predeploys.ERC721_ETHSCRIPTIONS_COLLECTION_IMPLEMENTATION, "ERC721EthscriptionsCollection");
         _setCodeAt(Predeploys.NAME_REGISTRY, "NameRegistry");

--- a/contracts/src/ERC721EthscriptionsCollection.sol
+++ b/contracts/src/ERC721EthscriptionsCollection.sol
@@ -101,12 +101,24 @@ contract ERC721EthscriptionsCollection is ERC721EthscriptionsEnumerableUpgradeab
             manager.getCollectionItem(collectionId, tokenId);
         if (item.ethscriptionId == bytes32(0)) revert("Token not in collection");
 
+        // Get the ethscription data to extract the ethscription number
+        Ethscriptions.Ethscription memory ethscription = ethscriptions.getEthscription(item.ethscriptionId, false);
+
         (string memory mediaType, string memory mediaUri) = ethscriptions.getMediaUri(item.ethscriptionId);
+
+        // Convert ethscriptionId to hex string (0x prefixed)
+        string memory ethscriptionIdHex = uint256(item.ethscriptionId).toHexString(32);
 
         string memory jsonStart = string.concat('{"name":"', item.name.escapeJSON(), '"');
         if (bytes(item.description).length > 0) {
             jsonStart = string.concat(jsonStart, ',"description":"', item.description.escapeJSON(), '"');
         }
+
+        // Add ethscription ID and number
+        string memory ethscriptionFields = string.concat(
+            ',"ethscription_id":"', ethscriptionIdHex, '"',
+            ',"ethscription_number":', ethscription.ethscriptionNumber.toString()
+        );
 
         string memory mediaField = string.concat(
             ',"',
@@ -135,7 +147,7 @@ contract ERC721EthscriptionsCollection is ERC721EthscriptionsEnumerableUpgradeab
         }
         attributesJson = string.concat(attributesJson, ']');
 
-        string memory json = string.concat(jsonStart, mediaField, bgColor, attributesJson, '}');
+        string memory json = string.concat(jsonStart, ethscriptionFields, mediaField, bgColor, attributesJson, '}');
 
         return string.concat("data:application/json;base64,", Base64.encode(bytes(json)));
     }

--- a/contracts/src/NameRegistry.sol
+++ b/contracts/src/NameRegistry.sol
@@ -189,15 +189,23 @@ contract NameRegistry is ERC721EthscriptionsEnumerableUpgradeable, IProtocolHand
         if (record.ethscriptionId == bytes32(0)) revert TokenDoesNotExist();
         string memory name = LibString.unpackOne(record.packedName);
 
+        // Get the ethscription data to extract the ethscription number
+        Ethscriptions.Ethscription memory ethscription = ethscriptions.getEthscription(record.ethscriptionId, false);
+
+        // Convert ethscriptionId to hex string (0x prefixed)
+        string memory ethscriptionIdHex = uint256(record.ethscriptionId).toHexString(32);
+
         bytes memory json = abi.encodePacked(
             '{"name":"',
             name,
-            '","description":"Dotless word domain","attributes":[',
+            '","description":"Dotless word domain"',
+            ',"ethscription_id":"',
+            ethscriptionIdHex,
+            '","ethscription_number":',
+            ethscription.ethscriptionNumber.toString(),
+            ',"attributes":[',
             '{"trait_type":"Name","value":"',
             name,
-            '"},',
-            '{"trait_type":"Ethscription","value":"',
-            _bytes32ToHex(record.ethscriptionId),
             '"}',
             ']}'
         );
@@ -210,10 +218,6 @@ contract NameRegistry is ERC721EthscriptionsEnumerableUpgradeable, IProtocolHand
             revert TransfersDisabled();
         }
         return super._update(to, tokenId, auth);
-    }
-
-    function _bytes32ToHex(bytes32 data) internal pure returns (string memory) {
-        return Strings.toHexString(uint256(data), 32);
     }
 
     function _domainInfo(bytes32 nameKey) internal view returns (DomainInfo memory info) {

--- a/contracts/src/libraries/EthscriptionsRendererLib.sol
+++ b/contracts/src/libraries/EthscriptionsRendererLib.sol
@@ -32,7 +32,7 @@ library EthscriptionsRendererLib {
         // Build in chunks to avoid stack too deep
         string memory part1 = string.concat(
             '[{"trait_type":"Ethscription ID","value":"',
-            uint256(ethscriptionId).toHexString(),
+            uint256(ethscriptionId).toHexString(32),
             '"},{"trait_type":"Ethscription Number","display_type":"number","value":',
             etsc.ethscriptionNumber.toString(),
             '},{"trait_type":"Creator","value":"',
@@ -43,7 +43,7 @@ library EthscriptionsRendererLib {
 
         string memory part2 = string.concat(
             '"},{"trait_type":"Content Hash","value":"',
-            uint256(etsc.contentHash).toHexString(),
+            uint256(etsc.contentHash).toHexString(32),
             '"},{"trait_type":"MIME Type","value":"',
             mimetype.escapeJSON(),
             '"},{"trait_type":"ESIP-6","value":"',

--- a/contracts/test/CollectionURIResolution.t.sol
+++ b/contracts/test/CollectionURIResolution.t.sol
@@ -72,7 +72,7 @@ contract CollectionURIResolutionTest is TestSetup {
         // Create collection with esc:// reference to the image
         string memory escUri = string.concat(
             "esc://ethscriptions/",
-            uint256(IMAGE_ETSC_TX_HASH).toHexString(),
+            uint256(IMAGE_ETSC_TX_HASH).toHexString(32),
             "/data"
         );
 
@@ -99,7 +99,7 @@ contract CollectionURIResolutionTest is TestSetup {
         bytes32 fakeId = keccak256("nonexistent");
         string memory escUri = string.concat(
             "esc://ethscriptions/",
-            uint256(fakeId).toHexString(),
+            uint256(fakeId).toHexString(32),
             "/data"
         );
 

--- a/contracts/test/CollectionsManager.t.sol
+++ b/contracts/test/CollectionsManager.t.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.8.24;
 import "./TestSetup.sol";
 import "../src/ERC721EthscriptionsCollectionManager.sol";
 import "../src/ERC721EthscriptionsCollection.sol";
+import "../src/libraries/Constants.sol";
 import {LibString} from "solady/utils/LibString.sol";
 
 contract ERC721EthscriptionsCollectionManagerTest is TestSetup {
@@ -939,5 +940,492 @@ contract ERC721EthscriptionsCollectionManagerTest is TestSetup {
         // Verify item was not changed
         ERC721EthscriptionsCollectionManager.CollectionItem memory item = collectionsHandler.getCollectionItem(COLLECTION_TX_HASH, 0);
         assertEq(item.name, "Test Item #0"); // Original name preserved
+    }
+
+    function testNonOwnerCanAddItemWithValidMerkleProof() public {
+        _exitImportMode();
+        bytes memory allowlistedContent = bytes("allowlisted-item");
+        bytes memory siblingContent = bytes("sibling-item");
+
+        ERC721EthscriptionsCollectionManager.Attribute[] memory allowlistedAttributes =
+            _attributeArray("Tier", "Founder");
+        ERC721EthscriptionsCollectionManager.Attribute[] memory siblingAttributes =
+            _attributeArray("Tier", "Guest");
+
+        bytes32 allowlistedLeaf = _computeLeafHash(
+            keccak256(allowlistedContent),
+            0,
+            "Allowlisted Item",
+            "#111111",
+            "Reserved for the allowlist",
+            allowlistedAttributes
+        );
+        bytes32 siblingLeaf = _computeLeafHash(
+            keccak256(siblingContent),
+            1,
+            "Sibling Item",
+            "#222222",
+            "Another whitelisted entry",
+            siblingAttributes
+        );
+
+        bytes32 merkleRoot = _hashPair(allowlistedLeaf, siblingLeaf);
+        _createCollectionWithMerkleRoot(COLLECTION_TX_HASH, merkleRoot);
+
+        ERC721EthscriptionsCollectionManager.ItemData memory itemData =
+            ERC721EthscriptionsCollectionManager.ItemData({
+                contentHash: keccak256(allowlistedContent),
+                itemIndex: 0,
+                name: "Allowlisted Item",
+                backgroundColor: "#111111",
+                description: "Reserved for the allowlist",
+                attributes: allowlistedAttributes,
+                merkleProof: _singleProofArray(siblingLeaf)
+            });
+
+        ERC721EthscriptionsCollectionManager.AddSelfToCollectionParams memory addSelfParams =
+            ERC721EthscriptionsCollectionManager.AddSelfToCollectionParams({
+                collectionId: COLLECTION_TX_HASH,
+                item: itemData
+            });
+
+        Ethscriptions.CreateEthscriptionParams memory addParams = Ethscriptions.CreateEthscriptionParams({
+            ethscriptionId: ITEM1_TX_HASH,
+            contentUriSha: sha256(allowlistedContent),
+            initialOwner: bob,
+            content: allowlistedContent,
+            mimetype: "text/plain",
+            esip6: false,
+            protocolParams: Ethscriptions.ProtocolParams({
+                protocolName: "erc-721-ethscriptions-collection",
+                operation: "add_self_to_collection",
+                data: abi.encode(addSelfParams)
+            })
+        });
+
+        vm.prank(bob);
+        ethscriptions.createEthscription(addParams);
+
+        address collectionAddress = collectionsHandler.getCollectionAddress(COLLECTION_TX_HASH);
+        assertTrue(collectionAddress != address(0));
+        ERC721EthscriptionsCollection collection = ERC721EthscriptionsCollection(collectionAddress);
+
+        assertEq(collection.ownerOf(0), bob);
+        ERC721EthscriptionsCollectionManager.CollectionItem memory stored = collectionsHandler.getCollectionItem(COLLECTION_TX_HASH, 0);
+        assertEq(stored.ethscriptionId, ITEM1_TX_HASH);
+        assertEq(stored.name, "Allowlisted Item");
+    }
+
+    function testNonOwnerCannotAddItemWithoutMerkleRoot() public {
+        _exitImportMode();
+        _createCollectionWithMerkleRoot(COLLECTION_TX_HASH, bytes32(0));
+
+        bytes memory allowlistedContent = bytes("allowlisted-item");
+        ERC721EthscriptionsCollectionManager.Attribute[] memory attributes =
+            _attributeArray("Tier", "Founder");
+
+        ERC721EthscriptionsCollectionManager.ItemData memory itemData =
+            ERC721EthscriptionsCollectionManager.ItemData({
+                contentHash: keccak256(allowlistedContent),
+                itemIndex: 0,
+                name: "Allowlisted Item",
+                backgroundColor: "#111111",
+                description: "Reserved for the allowlist",
+                attributes: attributes,
+                merkleProof: new bytes32[](0)
+            });
+
+        ERC721EthscriptionsCollectionManager.AddSelfToCollectionParams memory addSelfParams =
+            ERC721EthscriptionsCollectionManager.AddSelfToCollectionParams({
+                collectionId: COLLECTION_TX_HASH,
+                item: itemData
+            });
+
+        Ethscriptions.CreateEthscriptionParams memory addParams = Ethscriptions.CreateEthscriptionParams({
+            ethscriptionId: ITEM1_TX_HASH,
+            contentUriSha: sha256(allowlistedContent),
+            initialOwner: bob,
+            content: allowlistedContent,
+            mimetype: "text/plain",
+            esip6: false,
+            protocolParams: Ethscriptions.ProtocolParams({
+                protocolName: "erc-721-ethscriptions-collection",
+                operation: "add_self_to_collection",
+                data: abi.encode(addSelfParams)
+            })
+        });
+
+        vm.recordLogs();
+        vm.prank(bob);
+        ethscriptions.createEthscription(addParams);
+
+        _assertProtocolFailure(ITEM1_TX_HASH, "Merkle proof required");
+
+        ERC721EthscriptionsCollectionManager.CollectionItem memory stored =
+            collectionsHandler.getCollectionItem(COLLECTION_TX_HASH, 0);
+        assertEq(stored.ethscriptionId, bytes32(0));
+
+        ERC721EthscriptionsCollectionManager.Membership memory membership =
+            collectionsHandler.getMembershipOfEthscription(ITEM1_TX_HASH);
+        assertEq(membership.collectionId, bytes32(0));
+    }
+
+    function testNonOwnerCannotAddItemWithInvalidMerkleProof() public {
+        _exitImportMode();
+        bytes memory allowlistedContent = bytes("allowlisted-item");
+        bytes memory siblingContent = bytes("sibling-item");
+
+        ERC721EthscriptionsCollectionManager.Attribute[] memory allowlistedAttributes =
+            _attributeArray("Tier", "Founder");
+        ERC721EthscriptionsCollectionManager.Attribute[] memory siblingAttributes =
+            _attributeArray("Tier", "Guest");
+
+        bytes32 allowlistedLeaf = _computeLeafHash(
+            keccak256(allowlistedContent),
+            0,
+            "Allowlisted Item",
+            "#111111",
+            "Reserved for the allowlist",
+            allowlistedAttributes
+        );
+        bytes32 siblingLeaf = _computeLeafHash(
+            keccak256(siblingContent),
+            1,
+            "Sibling Item",
+            "#222222",
+            "Another whitelisted entry",
+            siblingAttributes
+        );
+
+        bytes32 merkleRoot = _hashPair(allowlistedLeaf, siblingLeaf);
+        _createCollectionWithMerkleRoot(COLLECTION_TX_HASH, merkleRoot);
+
+        bytes32[] memory invalidProof = new bytes32[](1);
+        invalidProof[0] = bytes32(uint256(0xdeadbeef));
+
+        ERC721EthscriptionsCollectionManager.ItemData memory itemData =
+            ERC721EthscriptionsCollectionManager.ItemData({
+                contentHash: keccak256(allowlistedContent),
+                itemIndex: 0,
+                name: "Allowlisted Item",
+                backgroundColor: "#111111",
+                description: "Reserved for the allowlist",
+                attributes: allowlistedAttributes,
+                merkleProof: invalidProof
+            });
+
+        ERC721EthscriptionsCollectionManager.AddSelfToCollectionParams memory addSelfParams =
+            ERC721EthscriptionsCollectionManager.AddSelfToCollectionParams({
+                collectionId: COLLECTION_TX_HASH,
+                item: itemData
+            });
+
+        Ethscriptions.CreateEthscriptionParams memory addParams = Ethscriptions.CreateEthscriptionParams({
+            ethscriptionId: ITEM1_TX_HASH,
+            contentUriSha: sha256(allowlistedContent),
+            initialOwner: bob,
+            content: allowlistedContent,
+            mimetype: "text/plain",
+            esip6: false,
+            protocolParams: Ethscriptions.ProtocolParams({
+                protocolName: "erc-721-ethscriptions-collection",
+                operation: "add_self_to_collection",
+                data: abi.encode(addSelfParams)
+            })
+        });
+
+        vm.recordLogs();
+        vm.prank(bob);
+        ethscriptions.createEthscription(addParams);
+
+        _assertProtocolFailure(ITEM1_TX_HASH, "Invalid Merkle proof");
+
+        ERC721EthscriptionsCollectionManager.CollectionItem memory stored =
+            collectionsHandler.getCollectionItem(COLLECTION_TX_HASH, 0);
+        assertEq(stored.ethscriptionId, bytes32(0));
+
+        ERC721EthscriptionsCollectionManager.Membership memory membership =
+            collectionsHandler.getMembershipOfEthscription(ITEM1_TX_HASH);
+        assertEq(membership.collectionId, bytes32(0));
+    }
+
+    function testCollectionOwnerBypassesMerkleProof() public {
+        _exitImportMode();
+        bytes32 enforcedRoot = keccak256("allowlist-root");
+        _createCollectionWithMerkleRoot(COLLECTION_TX_HASH, enforcedRoot);
+
+        bytes memory itemContent = bytes("owner-merkle-item");
+        ERC721EthscriptionsCollectionManager.Attribute[] memory attributes = _attributeArray("Tier", "Owner");
+
+        ERC721EthscriptionsCollectionManager.ItemData memory itemData =
+            ERC721EthscriptionsCollectionManager.ItemData({
+                contentHash: keccak256(itemContent),
+                itemIndex: 0,
+                name: "Owner Item",
+                backgroundColor: "#010101",
+                description: "Owner should bypass proof enforcement",
+                attributes: attributes,
+                merkleProof: new bytes32[](0)
+            });
+
+        ERC721EthscriptionsCollectionManager.AddSelfToCollectionParams memory addSelfParams =
+            ERC721EthscriptionsCollectionManager.AddSelfToCollectionParams({
+                collectionId: COLLECTION_TX_HASH,
+                item: itemData
+            });
+
+        Ethscriptions.CreateEthscriptionParams memory addParams = Ethscriptions.CreateEthscriptionParams({
+            ethscriptionId: ITEM1_TX_HASH,
+            contentUriSha: sha256(itemContent),
+            initialOwner: alice,
+            content: itemContent,
+            mimetype: "text/plain",
+            esip6: false,
+            protocolParams: Ethscriptions.ProtocolParams({
+                protocolName: "erc-721-ethscriptions-collection",
+                operation: "add_self_to_collection",
+                data: abi.encode(addSelfParams)
+            })
+        });
+
+        vm.prank(alice);
+        ethscriptions.createEthscription(addParams);
+
+        address collectionAddress = collectionsHandler.getCollectionAddress(COLLECTION_TX_HASH);
+        ERC721EthscriptionsCollection collection = ERC721EthscriptionsCollection(collectionAddress);
+        assertEq(collection.ownerOf(0), alice);
+
+        ERC721EthscriptionsCollectionManager.CollectionItem memory stored =
+            collectionsHandler.getCollectionItem(COLLECTION_TX_HASH, 0);
+        assertEq(stored.ethscriptionId, ITEM1_TX_HASH);
+    }
+
+    function testEditingMerkleRootChangesNonOwnerAccess() public {
+        _exitImportMode();
+
+        bytes memory allowlistedContent = bytes("allowlisted-item");
+        bytes memory siblingContent = bytes("sibling-item");
+
+        ERC721EthscriptionsCollectionManager.Attribute[] memory allowlistedAttributes =
+            _attributeArray("Tier", "Founder");
+        ERC721EthscriptionsCollectionManager.Attribute[] memory siblingAttributes =
+            _attributeArray("Tier", "Guest");
+
+        bytes32 allowlistedLeaf = _computeLeafHash(
+            keccak256(allowlistedContent),
+            0,
+            "Allowlisted Item",
+            "#111111",
+            "Reserved for the allowlist",
+            allowlistedAttributes
+        );
+        bytes32 siblingLeaf = _computeLeafHash(
+            keccak256(siblingContent),
+            1,
+            "Sibling Item",
+            "#222222",
+            "Another whitelisted entry",
+            siblingAttributes
+        );
+
+        bytes32 merkleRoot = _hashPair(allowlistedLeaf, siblingLeaf);
+        _createCollectionWithMerkleRoot(COLLECTION_TX_HASH, bytes32(0));
+
+        ERC721EthscriptionsCollectionManager.ItemData memory itemData =
+            ERC721EthscriptionsCollectionManager.ItemData({
+                contentHash: keccak256(allowlistedContent),
+                itemIndex: 0,
+                name: "Allowlisted Item",
+                backgroundColor: "#111111",
+                description: "Reserved for the allowlist",
+                attributes: allowlistedAttributes,
+                merkleProof: _singleProofArray(siblingLeaf)
+            });
+
+        ERC721EthscriptionsCollectionManager.AddSelfToCollectionParams memory addSelfParams =
+            ERC721EthscriptionsCollectionManager.AddSelfToCollectionParams({
+                collectionId: COLLECTION_TX_HASH,
+                item: itemData
+            });
+
+        Ethscriptions.CreateEthscriptionParams memory firstAttempt = Ethscriptions.CreateEthscriptionParams({
+            ethscriptionId: ITEM1_TX_HASH,
+            contentUriSha: sha256(allowlistedContent),
+            initialOwner: bob,
+            content: allowlistedContent,
+            mimetype: "text/plain",
+            esip6: false,
+            protocolParams: Ethscriptions.ProtocolParams({
+                protocolName: "erc-721-ethscriptions-collection",
+                operation: "add_self_to_collection",
+                data: abi.encode(addSelfParams)
+            })
+        });
+
+        vm.recordLogs();
+        vm.prank(bob);
+        ethscriptions.createEthscription(firstAttempt);
+        _assertProtocolFailure(ITEM1_TX_HASH, "Merkle proof required");
+
+        ERC721EthscriptionsCollectionManager.CollectionItem memory emptySlot =
+            collectionsHandler.getCollectionItem(COLLECTION_TX_HASH, 0);
+        assertEq(emptySlot.ethscriptionId, bytes32(0));
+
+        _editCollectionMerkleRoot(bytes32(uint256(0xED111)), COLLECTION_TX_HASH, merkleRoot);
+
+        Ethscriptions.CreateEthscriptionParams memory secondAttempt = Ethscriptions.CreateEthscriptionParams({
+            ethscriptionId: ITEM2_TX_HASH,
+            contentUriSha: sha256(allowlistedContent),
+            initialOwner: bob,
+            content: allowlistedContent,
+            mimetype: "text/plain",
+            esip6: true,
+            protocolParams: Ethscriptions.ProtocolParams({
+                protocolName: "erc-721-ethscriptions-collection",
+                operation: "add_self_to_collection",
+                data: abi.encode(addSelfParams)
+            })
+        });
+
+        vm.prank(bob);
+        ethscriptions.createEthscription(secondAttempt);
+
+        ERC721EthscriptionsCollectionManager.CollectionItem memory stored =
+            collectionsHandler.getCollectionItem(COLLECTION_TX_HASH, 0);
+        assertEq(stored.ethscriptionId, ITEM2_TX_HASH);
+
+        ERC721EthscriptionsCollectionManager.Membership memory membership =
+            collectionsHandler.getMembershipOfEthscription(ITEM2_TX_HASH);
+        assertEq(membership.collectionId, COLLECTION_TX_HASH);
+        assertEq(membership.tokenIdPlusOne, 1);
+
+        ERC721EthscriptionsCollectionManager.CollectionMetadata memory metadata =
+            collectionsHandler.getCollection(COLLECTION_TX_HASH);
+        assertEq(metadata.merkleRoot, merkleRoot);
+    }
+
+    function _createCollectionWithMerkleRoot(bytes32 collectionId, bytes32 merkleRoot) private {
+        ERC721EthscriptionsCollectionManager.CollectionParams memory metadata =
+            ERC721EthscriptionsCollectionManager.CollectionParams({
+                name: "Merkle Collection",
+                symbol: "MRKL",
+                maxSupply: 100,
+                description: "Collection that requires proofs",
+                logoImageUri: "",
+                bannerImageUri: "",
+                backgroundColor: "",
+                websiteLink: "",
+                twitterLink: "",
+                discordLink: "",
+                merkleRoot: merkleRoot
+            });
+
+        string memory collectionContent =
+            'data:,{"p":"erc-721-ethscriptions-collection","op":"create_collection","name":"Merkle Collection"}';
+
+        Ethscriptions.CreateEthscriptionParams memory params = Ethscriptions.CreateEthscriptionParams({
+            ethscriptionId: collectionId,
+            contentUriSha: sha256(bytes(collectionContent)),
+            initialOwner: alice,
+            content: bytes(collectionContent),
+            mimetype: "application/json",
+            esip6: false,
+            protocolParams: Ethscriptions.ProtocolParams({
+                protocolName: "erc-721-ethscriptions-collection",
+                operation: "create_collection",
+                data: abi.encode(metadata)
+            })
+        });
+
+        vm.prank(alice);
+        ethscriptions.createEthscription(params);
+    }
+
+    function _attributeArray(string memory trait, string memory value)
+        private
+        pure
+        returns (ERC721EthscriptionsCollectionManager.Attribute[] memory attrs)
+    {
+        attrs = new ERC721EthscriptionsCollectionManager.Attribute[](1);
+        attrs[0] = ERC721EthscriptionsCollectionManager.Attribute({traitType: trait, value: value});
+    }
+
+    function _computeLeafHash(
+        bytes32 contentHash,
+        uint256 itemIndex,
+        string memory name,
+        string memory backgroundColor,
+        string memory description,
+        ERC721EthscriptionsCollectionManager.Attribute[] memory attributes
+    ) private pure returns (bytes32) {
+        return keccak256(abi.encode(contentHash, itemIndex, name, backgroundColor, description, attributes));
+    }
+
+    function _hashPair(bytes32 a, bytes32 b) private pure returns (bytes32) {
+        return a < b ? keccak256(abi.encodePacked(a, b)) : keccak256(abi.encodePacked(b, a));
+    }
+
+    function _singleProofArray(bytes32 sibling) private pure returns (bytes32[] memory proof) {
+        proof = new bytes32[](1);
+        proof[0] = sibling;
+    }
+
+    function _assertProtocolFailure(bytes32 ethscriptionId, string memory expectedMessage) private {
+        Vm.Log[] memory logs = vm.getRecordedLogs();
+        bytes32 failureTopic = keccak256("ProtocolHandlerFailed(bytes32,string,bytes)");
+        bool found;
+        string memory protocol;
+        bytes memory revertData;
+
+        for (uint256 i = 0; i < logs.length; i++) {
+            Vm.Log memory entry = logs[i];
+            if (entry.topics.length >= 2 && entry.topics[0] == failureTopic && entry.topics[1] == ethscriptionId) {
+                (protocol, revertData) = abi.decode(entry.data, (string, bytes));
+                found = true;
+                break;
+            }
+        }
+
+        assertTrue(found, "Expected ProtocolHandlerFailed event");
+        assertEq(protocol, "erc-721-ethscriptions-collection");
+
+        bytes memory expected = abi.encodeWithSignature("Error(string)", expectedMessage);
+        assertEq(keccak256(revertData), keccak256(expected));
+    }
+
+    function _exitImportMode() private {
+        vm.warp(Constants.historicalBackfillApproxDoneAt + 1);
+    }
+
+    function _editCollectionMerkleRoot(bytes32 editEthscriptionId, bytes32 collectionId, bytes32 newRoot) private {
+        ERC721EthscriptionsCollectionManager.EditCollectionOperation memory editOp =
+            ERC721EthscriptionsCollectionManager.EditCollectionOperation({
+                collectionId: collectionId,
+                description: "",
+                logoImageUri: "",
+                bannerImageUri: "",
+                backgroundColor: "",
+                websiteLink: "",
+                twitterLink: "",
+                discordLink: "",
+                merkleRoot: newRoot
+            });
+
+        Ethscriptions.CreateEthscriptionParams memory editParams = Ethscriptions.CreateEthscriptionParams({
+            ethscriptionId: editEthscriptionId,
+            contentUriSha: sha256(bytes("edit-merkle")),
+            initialOwner: alice,
+            content: bytes("edit-merkle"),
+            mimetype: "text/plain",
+            esip6: false,
+            protocolParams: Ethscriptions.ProtocolParams({
+                protocolName: "erc-721-ethscriptions-collection",
+                operation: "edit_collection",
+                data: abi.encode(editOp)
+            })
+        });
+
+        vm.prank(alice);
+        ethscriptions.createEthscription(editParams);
     }
 }

--- a/lib/ethscriptions_api_client.rb
+++ b/lib/ethscriptions_api_client.rb
@@ -48,6 +48,29 @@ class EthscriptionsApiClient
       })
     end
 
+    def fetch_single_ethscription(number)
+      # Fetch a single ethscription by its number
+      path = "/ethscriptions/#{number}"
+
+      begin
+        data = fetch_json(path)
+        # The show endpoint returns the ethscription directly
+        normalize_creations([data['result']]).first
+      rescue HttpError => e
+        if e.code == 404
+          # Ethscription doesn't exist
+          nil
+        else
+          # Re-raise other HTTP errors for retry handling
+          raise
+        end
+      end
+    rescue HttpError, ApiError, NetworkError => e
+      # Wrap all internal errors into a single type for callers
+      Rails.logger.error "API unavailable for ethscription ##{number} after retries: #{e.message}"
+      raise ApiUnavailableError, "API unavailable after #{ENV.fetch('ETHSCRIPTIONS_API_RETRIES', 7)} retries: #{e.message}"
+    end
+
     def fetch_paginated(path, params)
       results = []
       page_key = nil
@@ -130,13 +153,13 @@ class EthscriptionsApiClient
         current_owner = (item['current_owner'] || '').downcase
         previous_owner = (item['previous_owner'] || '').downcase
 
-        # Decode the b64_content field if present
         content = Base64.decode64(item['b64_content'])
 
         {
           tx_hash: tx_hash,
           transaction_hash: tx_hash, # Include both for compatibility
           block_number: item['block_number'],
+          l1_block_number: item['block_number'],
           transaction_index: item['transaction_index'],
           block_timestamp: item['block_timestamp'],
           block_blockhash: item['block_blockhash'],
@@ -147,7 +170,7 @@ class EthscriptionsApiClient
           current_owner: current_owner,
           previous_owner: previous_owner,
           content_uri: item['content_uri'],
-          content_sha: "0x" + Digest::SHA256.hexdigest(content),
+          content_hash: "0x" +  Eth::Util.keccak256(content).unpack1('H*'),
           esip6: item['esip6'] || false,
           mimetype: item['mimetype'],
           media_type: item['media_type'],

--- a/lib/ethscriptions_api_client.rb
+++ b/lib/ethscriptions_api_client.rb
@@ -170,7 +170,7 @@ class EthscriptionsApiClient
           current_owner: current_owner,
           previous_owner: previous_owner,
           content_uri: item['content_uri'],
-          content_hash: "0x" +  Eth::Util.keccak256(content).unpack1('H*'),
+          content_hash: "0x" + Eth::Util.keccak256(content).unpack1('H*'),
           esip6: item['esip6'] || false,
           mimetype: item['mimetype'],
           media_type: item['media_type'],

--- a/lib/storage_reader.rb
+++ b/lib/storage_reader.rb
@@ -157,10 +157,10 @@ class StorageReader
         protocol_name: ethscription_data[15],
         operation: ethscription_data[16]
       }
-    rescue => e
-      Rails.logger.error "Failed to get ethscription with content #{tx_hash}: #{e.message}"
-      Rails.logger.error e.backtrace.join("\n") if Rails.env.development?
-      raise e
+    rescue EthRpcClient::ExecutionRevertedError => e
+      # Contract reverted - ethscription doesn't exist
+      Rails.logger.debug "Ethscription #{tx_hash} doesn't exist (contract reverted): #{e.message}"
+      nil
     end
 
     def get_ethscription(tx_hash, block_tag: 'latest')


### PR DESCRIPTION
- Updated `L2Genesis` to include `NAME_REGISTRY` as a proxied contract.
- Enhanced `ERC721EthscriptionsCollection` and `NameRegistry` to include ethscription ID and number in JSON metadata.
- Improved URI resolution in tests to ensure consistent hex string formatting for ethscription IDs.
- Added new methods in `EthscriptionsApiClient` for fetching single ethscription data and handling errors more gracefully.
- Refactored content hash calculation in `EthscriptionsApiClient` for improved accuracy.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds proxied `NAME_REGISTRY`, includes ethscription ID/number in token metadata with fixed 32-byte hex, introduces Merkle allowlist tests, and improves API client/storage reader behavior.
> 
> - **Contracts**:
>   - **Genesis/Predeploys**: Treat `Predeploys.NAME_REGISTRY` as a proxied contract; set implementation via `_setImplementationCodeNamed`.
>   - **Metadata**: `ERC721EthscriptionsCollection.tokenURI` and `NameRegistry.tokenURI` now include `ethscription_id` (0x + 32-byte hex) and numeric `ethscription_number`.
>   - **Rendering**: Standardize hex formatting to 32-byte in `EthscriptionsRendererLib` for `ethscriptionId` and `contentHash`.
> - **Tests**:
>   - Update URI resolution to use 32-byte hex in `esc://` references.
>   - Add Merkle allowlist coverage: valid proof by non-owner, required/invalid proof failures, owner bypass, and dynamic root updates in `CollectionsManager.t.sol`.
> - **Ruby Backend**:
>   - `EthscriptionsApiClient`: add `fetch_single_ethscription`; compute `content_hash` via keccak256; expose `l1_block_number`; robust error handling.
>   - `StorageReader`: return nil on contract reverts for missing ethscription; use includeContent=false path with graceful handling.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9e9b9c85a1316a8098fef11b8d74fda7143232e0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->