### PR TITLE
Enhance ERC721 Contracts with Base64 Metadata Encoding

### DIFF
--- a/app/models/erc721_ethscriptions_collection_parser.rb
+++ b/app/models/erc721_ethscriptions_collection_parser.rb
@@ -53,6 +53,21 @@ class Erc721EthscriptionsCollectionParser
         'item' => :single_item
       }
     },
+    'transfer_ownership' => {
+      keys: %w[collection_id new_owner],
+      abi_type: '(bytes32,address)',
+      validators: {
+        'collection_id' => :bytes32,
+        'new_owner' => :address
+      }
+    },
+    'renounce_ownership' => {
+      keys: %w[collection_id],
+      abi_type: 'bytes32',
+      validators: {
+        'collection_id' => :bytes32
+      }
+    },
     'remove_items' => {
       keys: %w[collection_id ethscription_ids],
       abi_type: '(bytes32,bytes32[])',
@@ -399,6 +414,10 @@ class Erc721EthscriptionsCollectionParser
       build_create_and_add_self_values(validated_data, content_hash: content_hash)
     when 'add_self_to_collection'
       build_add_self_to_collection_values(validated_data, content_hash: content_hash)
+    when 'transfer_ownership'
+      build_transfer_ownership_values(validated_data)
+    when 'renounce_ownership'
+      build_renounce_ownership_values(validated_data)
     when 'remove_items'
       build_remove_items_values(validated_data)
     when 'edit_collection'
@@ -486,6 +505,18 @@ class Erc721EthscriptionsCollectionParser
     end
     # Return as packed bytes for ABI encoding
     [value[2..]].pack('H*')
+  end
+
+  def validate_address(value, field_name)
+    unless value.is_a?(String) && value.match?(/\A0x[0-9a-f]{40}\z/)
+      raise ValidationError, "Invalid address for #{field_name}: #{value}"
+    end
+
+    if value == '0x0000000000000000000000000000000000000000'
+      raise ValidationError, "Address cannot be zero for #{field_name}"
+    end
+
+    value.downcase
   end
 
   def validate_bytes32_array(value, field_name)
@@ -673,6 +704,14 @@ class Erc721EthscriptionsCollectionParser
       item[:merkleProof]
     ]
     [data['collection_id'], item_tuple]
+  end
+
+  def build_transfer_ownership_values(data)
+    [data['collection_id'], data['new_owner']]
+  end
+
+  def build_renounce_ownership_values(data)
+    data['collection_id']
   end
 
   def build_remove_items_values(data)

--- a/contracts/src/ERC721EthscriptionsCollection.sol
+++ b/contracts/src/ERC721EthscriptionsCollection.sol
@@ -124,7 +124,7 @@ contract ERC721EthscriptionsCollection is ERC721EthscriptionsEnumerableUpgradeab
             ',"',
             mediaType,
             '":"',
-            mediaUri.escapeJSON(),
+            mediaUri,
             '"'
         );
 

--- a/contracts/src/ERC721EthscriptionsCollection.sol
+++ b/contracts/src/ERC721EthscriptionsCollection.sol
@@ -182,7 +182,7 @@ contract ERC721EthscriptionsCollection is ERC721EthscriptionsEnumerableUpgradeab
             '"}'
         );
 
-        return json;
+        return string.concat("data:application/json;base64,", Base64.encode(bytes(json)));
     }
 
     function safeTransferFrom(address, address, uint256, bytes memory)

--- a/contracts/src/ERC721EthscriptionsCollectionManager.sol
+++ b/contracts/src/ERC721EthscriptionsCollectionManager.sol
@@ -152,6 +152,7 @@ contract ERC721EthscriptionsCollectionManager is IProtocolHandler {
     event ItemsRemoved(bytes32 indexed collectionId, uint256 count, bytes32 updateTxHash);
     event CollectionEdited(bytes32 indexed collectionId);
     event CollectionLocked(bytes32 indexed collectionId);
+    event OwnershipTransferred(bytes32 indexed collectionId, address indexed previousOwner, address indexed newOwner);
 
     modifier onlyEthscriptions() {
         require(msg.sender == address(ethscriptions), "Only Ethscriptions contract");
@@ -182,6 +183,17 @@ contract ERC721EthscriptionsCollectionManager is IProtocolHandler {
         AddSelfToCollectionParams memory op = abi.decode(data, (AddSelfToCollectionParams));
 
         _addSingleItem(op.collectionId, ethscriptionId, op.item);
+    }
+
+    function op_transfer_ownership(bytes32 ethscriptionId, bytes calldata data) external onlyEthscriptions {
+        (bytes32 collectionId, address newOwner) = abi.decode(data, (bytes32, address));
+        require(newOwner != address(0), "New owner cannot be zero address");
+        _transferCollectionOwnership(ethscriptionId, collectionId, newOwner);
+    }
+
+    function op_renounce_ownership(bytes32 ethscriptionId, bytes calldata data) external onlyEthscriptions {
+        bytes32 collectionId = abi.decode(data, (bytes32));
+        _transferCollectionOwnership(ethscriptionId, collectionId, address(0));
     }
 
     function op_remove_items(bytes32 ethscriptionId, bytes calldata data) external onlyEthscriptions {
@@ -266,12 +278,6 @@ contract ERC721EthscriptionsCollectionManager is IProtocolHandler {
     }
 
     function onTransfer(bytes32 ethscriptionId, address from, address to) external override onlyEthscriptions {
-        if (collectionExists(ethscriptionId)) {
-            ERC721EthscriptionsCollection collection = ERC721EthscriptionsCollection(collectionStore[ethscriptionId].collectionContract);
-            collection.factoryTransferOwnership(to);
-            return;
-        }
-        
         Membership storage membership = membershipOfEthscription[ethscriptionId];
         
         if (!collectionExists(membership.collectionId)) {
@@ -454,6 +460,23 @@ contract ERC721EthscriptionsCollectionManager is IProtocolHandler {
         require(currentOwner == sender, errorMessage);
     }
 
+    function _transferCollectionOwnership(bytes32 ethscriptionId, bytes32 collectionId, address newOwner) private {
+        CollectionRecord storage collection = collectionStore[collectionId];
+        require(collection.collectionContract != address(0), "Collection does not exist");
+
+        address sender = _getEthscriptionCreator(ethscriptionId);
+        ERC721EthscriptionsCollection collectionContract = ERC721EthscriptionsCollection(collection.collectionContract);
+        address currentOwner = collectionContract.owner();
+        require(currentOwner == sender, "Only collection owner can transfer");
+
+        if (newOwner == currentOwner) {
+            revert("New owner must differ");
+        }
+
+        collectionContract.factoryTransferOwnership(newOwner);
+        emit OwnershipTransferred(collectionId, currentOwner, newOwner);
+    }
+
     function _verifyItemMerkleProof(ItemData memory item, bytes32 merkleRoot) private pure {
         require(merkleRoot != bytes32(0), "Merkle proof required");
 
@@ -488,4 +511,3 @@ contract ERC721EthscriptionsCollectionManager is IProtocolHandler {
         return getCollection(collectionId);
     }
 }
-

--- a/contracts/src/NameRegistry.sol
+++ b/contracts/src/NameRegistry.sol
@@ -12,7 +12,7 @@ import {IERC721} from "@openzeppelin/contracts/token/ERC721/IERC721.sol";
 /// @title NameRegistry
 /// @notice Handles legacy word-domain registrations and mirrors ownership as an ERC-721 collection.
 contract NameRegistry is ERC721EthscriptionsEnumerableUpgradeable, IProtocolHandler {
-    using LibString for uint256;
+    using LibString for *;
 
     Ethscriptions public constant ethscriptions = Ethscriptions(Predeploys.ETHSCRIPTIONS);
 
@@ -188,20 +188,27 @@ contract NameRegistry is ERC721EthscriptionsEnumerableUpgradeable, IProtocolHand
         // Get the ethscription data to extract the ethscription number
         Ethscriptions.Ethscription memory ethscription = ethscriptions.getEthscription(record.ethscriptionId, false);
 
+        // Get the media URI from the ethscription
+        (string memory mediaType, string memory mediaUri) = ethscriptions.getMediaUri(record.ethscriptionId);
+
         // Convert ethscriptionId to hex string (0x prefixed)
         string memory ethscriptionIdHex = uint256(record.ethscriptionId).toHexString(32);
 
         bytes memory json = abi.encodePacked(
             '{"name":"',
-            name,
+            name.escapeJSON(),
             '","description":"Dotless word domain"',
             ',"ethscription_id":"',
             ethscriptionIdHex,
             '","ethscription_number":',
             ethscription.ethscriptionNumber.toString(),
-            ',"attributes":[',
+            ',"',
+            mediaType,
+            '":"',
+            mediaUri,
+            '","attributes":[',
             '{"trait_type":"Name","value":"',
-            name,
+            name.escapeJSON(),
             '"}',
             ']}'
         );

--- a/contracts/src/NameRegistry.sol
+++ b/contracts/src/NameRegistry.sol
@@ -1,22 +1,22 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.24;
 
-import "@openzeppelin/contracts/utils/Strings.sol";
 import {Base64} from "solady/utils/Base64.sol";
 import {LibString} from "solady/utils/LibString.sol";
 import "./ERC721EthscriptionsEnumerableUpgradeable.sol";
 import "./interfaces/IProtocolHandler.sol";
 import "./Ethscriptions.sol";
 import "./libraries/Predeploys.sol";
+import {IERC721} from "@openzeppelin/contracts/token/ERC721/IERC721.sol";
 
 /// @title NameRegistry
 /// @notice Handles legacy word-domain registrations and mirrors ownership as an ERC-721 collection.
 contract NameRegistry is ERC721EthscriptionsEnumerableUpgradeable, IProtocolHandler {
-    using Strings for uint256;
+    using LibString for uint256;
 
     Ethscriptions public constant ethscriptions = Ethscriptions(Predeploys.ETHSCRIPTIONS);
 
-    string public constant PROTOCOL_NAME = "word-domains";
+    string public constant protocolName = "word-domains";
 
     struct DomainRecord {
         bytes32 packedName;
@@ -60,10 +60,6 @@ contract NameRegistry is ERC721EthscriptionsEnumerableUpgradeable, IProtocolHand
     
     function symbol() public view override returns (string memory) {
         return "NAME";
-    }
-
-    function protocolName() external pure returns (string memory) {
-        return PROTOCOL_NAME;
     }
 
     // ============================
@@ -211,6 +207,62 @@ contract NameRegistry is ERC721EthscriptionsEnumerableUpgradeable, IProtocolHand
         );
 
         return string(abi.encodePacked("data:application/json;base64,", Base64.encode(json)));
+    }
+
+    /// @notice OpenSea collection-level metadata
+    /// @return JSON string with collection metadata
+    function contractURI() external pure returns (string memory) {
+        return string(abi.encodePacked(
+            'data:application/json;base64,',
+            Base64.encode(bytes(
+                '{"name":"Word Domains Registry",'
+                '"description":"On-chain word domain name system for Ethscriptions. Register unique, dotless domain names as NFTs.",'
+                '"image":"data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iNTAwIiBoZWlnaHQ9IjUwMCIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj48cmVjdCB3aWR0aD0iNTAwIiBoZWlnaHQ9IjUwMCIgZmlsbD0iIzEwMTAxMCIvPjx0ZXh0IHg9IjI1MCIgeT0iMjUwIiBmb250LXNpemU9IjgwIiBmb250LWZhbWlseT0ibW9ub3NwYWNlIiB0ZXh0LWFuY2hvcj0ibWlkZGxlIiBmaWxsPSIjMDBmZjAwIj5bTkFNRVNdPC90ZXh0Pjwvc3ZnPg==",'
+                '"external_link":"https://ethscriptions.com"}'
+            ))
+        ));
+    }
+
+    // --- Transfer/approvals blocked externally ---------------------------------
+
+    function transferFrom(address, address, uint256)
+        public
+        pure
+        override(ERC721EthscriptionsUpgradeable, IERC721)
+    {
+        revert TransfersDisabled();
+    }
+
+    function safeTransferFrom(address, address, uint256)
+        public
+        pure
+        override(ERC721EthscriptionsUpgradeable, IERC721)
+    {
+        revert TransfersDisabled();
+    }
+
+    function safeTransferFrom(address, address, uint256, bytes memory)
+        public
+        pure
+        override(ERC721EthscriptionsUpgradeable, IERC721)
+    {
+        revert TransfersDisabled();
+    }
+
+    function approve(address, uint256)
+        public
+        pure
+        override(ERC721EthscriptionsUpgradeable, IERC721)
+    {
+        revert TransfersDisabled();
+    }
+
+    function setApprovalForAll(address, bool)
+        public
+        pure
+        override(ERC721EthscriptionsUpgradeable, IERC721)
+    {
+        revert TransfersDisabled();
     }
 
     function _update(address to, uint256 tokenId, address auth) internal override returns (address) {

--- a/contracts/test/CollectionURIResolution.t.sol
+++ b/contracts/test/CollectionURIResolution.t.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.8.24;
 
 import "./TestSetup.sol";
 import {LibString} from "solady/utils/LibString.sol";
+import {Base64} from "solady/utils/Base64.sol";
 
 contract CollectionURIResolutionTest is TestSetup {
     using LibString for *;
@@ -33,7 +34,18 @@ contract CollectionURIResolutionTest is TestSetup {
         string memory contractUri = collection.contractURI();
 
         assertTrue(bytes(contractUri).length > 0, "Should have contractURI");
-        assertTrue(contractUri.contains(regularUri), "Should contain original URI");
+
+        // contractURI returns base64-encoded JSON, decode it
+        // Check it starts with data URI prefix
+        string memory prefix = "data:application/json;base64,";
+        assertTrue(contractUri.startsWith(prefix), "Should be a data URI");
+
+        // Extract and decode the base64 part
+        string memory base64Part = contractUri.slice(bytes(prefix).length);
+        bytes memory decodedBytes = Base64.decode(base64Part);
+        string memory decodedJson = string(decodedBytes);
+
+        assertTrue(decodedJson.contains(regularUri), "Should contain original URI");
     }
 
     function test_DataURIPassesThrough() public {

--- a/spec/integration/collections_protocol_e2e_spec.rb
+++ b/spec/integration/collections_protocol_e2e_spec.rb
@@ -1,4 +1,5 @@
 require 'rails_helper'
+require_relative '../../lib/protocol_event_reader'
 
 RSpec.describe "Collections Protocol End-to-End", type: :integration do
   include EthscriptionsTestHelper
@@ -309,5 +310,189 @@ RSpec.describe "Collections Protocol End-to-End", type: :integration do
       expect(item1[:attributes].length).to eq(4)
       expect(item1[:attributes][0]).to eq(["Type", "Rare"])
     end
+  end
+
+  describe "Merkle Root Enforcement" do
+    let(:owner_merkle_root) { '0x' + '1' * 64 }
+
+    it "allows the collection owner to add an item without a proof when the root is set" do
+      collection_data = {
+        "p" => "erc-721-ethscriptions-collection",
+        "op" => "create_collection",
+        "name" => "Owner Only",
+        "symbol" => "OWNR",
+        "max_supply" => "10",
+        "description" => "Testing owner bypass",
+        "logo_image_uri" => "",
+        "banner_image_uri" => "",
+        "background_color" => "",
+        "website_link" => "",
+        "twitter_link" => "",
+        "discord_link" => "",
+        "merkle_root" => owner_merkle_root
+      }
+
+      collection_spec = create_input(
+        creator: alice,
+        to: alice,
+        data_uri: "data:," + JSON.generate(collection_data)
+      )
+
+      collection_results = import_l1_block([collection_spec], esip_overrides: { esip6_is_enabled: true })
+      expect(collection_results[:ethscription_ids]).not_to be_empty
+      collection_id = collection_results[:ethscription_ids].first
+
+      owner_item = {
+        "p" => "erc-721-ethscriptions-collection",
+        "op" => "add_self_to_collection",
+        "collection_id" => collection_id,
+        "item" => {
+          "item_index" => "0",
+          "name" => "Owner Item #0",
+          "background_color" => "#123456",
+          "description" => "Inserted by the owner without a proof",
+          "attributes" => [
+            {"trait_type" => "Tier", "value" => "Owner"}
+          ],
+          "merkle_proof" => []
+        }
+      }
+
+      owner_spec = create_input(
+        creator: alice,
+        to: alice,
+        data_uri: "data:," + JSON.generate(owner_item)
+      )
+
+      owner_results = import_l1_block([owner_spec], esip_overrides: { esip6_is_enabled: true })
+      expect(owner_results[:ethscription_ids]).not_to be_empty
+      owner_item_id = owner_results[:ethscription_ids].first
+
+      receipt = owner_results[:l2_receipts].first
+      events = ProtocolEventReader.parse_receipt_events(receipt)
+      expect(events.any? { |e| e[:event] == 'ProtocolHandlerFailed' }).to eq(false)
+      expect(events.any? { |e| e[:event] == 'ProtocolHandlerSuccess' }).to eq(true)
+
+      added_event = events.find { |e| e[:event] == 'ItemsAdded' }
+      expect(added_event).not_to be_nil
+      expect(added_event[:count]).to eq(1)
+
+      stored_item = get_collection_item(collection_id, 0)
+      expect(stored_item[:ethscriptionId]).to eq(owner_item_id)
+      expect(stored_item[:name]).to eq("Owner Item #0")
+    end
+
+    it "updates the merkle root via edit_collection to allow a non-owner add" do
+      initial_merkle_root = zero_merkle_root
+      collection_data = {
+        "p" => "erc-721-ethscriptions-collection",
+        "op" => "create_collection",
+        "name" => "Editable Root",
+        "symbol" => "EDIT",
+        "max_supply" => "10",
+        "description" => "Testing merkle root edits",
+        "logo_image_uri" => "",
+        "banner_image_uri" => "",
+        "background_color" => "",
+        "website_link" => "",
+        "twitter_link" => "",
+        "discord_link" => "",
+        "merkle_root" => initial_merkle_root
+      }
+
+      collection_spec = create_input(
+        creator: alice,
+        to: alice,
+        data_uri: "data:," + JSON.generate(collection_data)
+      )
+
+      collection_results = import_l1_block([collection_spec], esip_overrides: { esip6_is_enabled: true })
+      collection_id = collection_results[:ethscription_ids].first
+      expect(collection_id).to be_present
+      metadata_before_edit = get_collection_metadata(collection_id)
+      expect(metadata_before_edit[:merkleRoot].downcase).to eq(initial_merkle_root.downcase)
+
+      allowlist_attributes = [{"trait_type" => "Tier", "value" => "Founder"}]
+      item_template = {
+        "p" => "erc-721-ethscriptions-collection",
+        "op" => "add_self_to_collection",
+        "collection_id" => collection_id,
+        "item" => {
+          "item_index" => "0",
+          "name" => "Allowlisted Item #0",
+          "background_color" => "#abcdef",
+          "description" => "Non-owner entry gated by the root",
+          "attributes" => allowlist_attributes,
+          "merkle_proof" => []
+        }
+      }
+
+      item_json = JSON.generate(item_template)
+      content_hash_hex = "0x#{Eth::Util.keccak256(item_json).unpack1('H*')}"
+      attribute_pairs = allowlist_attributes.map { |attr| [attr["trait_type"], attr["value"]] }
+      computed_root = compute_single_leaf_root(
+        content_hash_hex: content_hash_hex,
+        item_index: 0,
+        name: item_template["item"]["name"],
+        background_color: item_template["item"]["background_color"],
+        description: item_template["item"]["description"],
+        attributes: attribute_pairs
+      )
+
+      edit_payload = {
+        "p" => "erc-721-ethscriptions-collection",
+        "op" => "edit_collection",
+        "collection_id" => collection_id,
+        "description" => "",
+        "logo_image_uri" => "",
+        "banner_image_uri" => "",
+        "background_color" => "",
+        "website_link" => "",
+        "twitter_link" => "",
+        "discord_link" => "",
+        "merkle_root" => computed_root
+      }
+
+      edit_spec = create_input(
+        creator: alice,
+        to: alice,
+        data_uri: "data:," + JSON.generate(edit_payload)
+      )
+
+      edit_results = import_l1_block([edit_spec], esip_overrides: { esip6_is_enabled: true })
+      expect(edit_results[:l2_receipts].first[:status]).to eq('0x1')
+
+      metadata_after_edit = get_collection_metadata(collection_id)
+      expect(metadata_after_edit[:merkleRoot].downcase).to eq(computed_root.downcase)
+
+      second_spec = create_input(
+        creator: bob,
+        to: bob,
+        data_uri: "data:," + item_json
+      )
+
+      success_results = import_l1_block([second_spec], esip_overrides: { esip6_is_enabled: true })
+      success_receipt = success_results[:l2_receipts].first
+      success_events = ProtocolEventReader.parse_receipt_events(success_receipt)
+      expect(success_events.any? { |e| e[:event] == 'ProtocolHandlerSuccess' }).to eq(true)
+      added_event = success_events.find { |e| e[:event] == 'ItemsAdded' }
+      expect(added_event).not_to be_nil
+      expect(added_event[:count]).to eq(1)
+
+      added_item_id = success_results[:ethscription_ids].first
+      stored_item = get_collection_item(collection_id, 0)
+      expect(stored_item[:ethscriptionId]).to eq(added_item_id)
+
+      expect(get_collection_metadata(collection_id)[:merkleRoot].downcase).to eq(computed_root.downcase)
+    end
+  end
+
+  def compute_single_leaf_root(content_hash_hex:, item_index:, name:, background_color:, description:, attributes:)
+    content_hash_bytes = [content_hash_hex.delete_prefix('0x')].pack('H*')
+    encoded = Eth::Abi.encode(
+      ['bytes32', 'uint256', 'string', 'string', 'string', '(string,string)[]'],
+      [content_hash_bytes, item_index, name, background_color, description, attributes]
+    )
+    "0x#{Eth::Util.keccak256(encoded).unpack1('H*')}"
   end
 end

--- a/spec/integration/collections_protocol_spec.rb
+++ b/spec/integration/collections_protocol_spec.rb
@@ -199,21 +199,150 @@ RSpec.describe "Collections Protocol", type: :integration do
       )
     end
 
-    it "transfers collection ownership" do
+    it "transfers collection ownership explicitly" do
+      collection_data = {
+        "p" => "erc-721-ethscriptions-collection",
+        "op" => "create_collection",
+        "name" => "Ownership Test",
+        "symbol" => "OWN",
+        "max_supply" => "10",
+        "description" => "",
+        "logo_image_uri" => "",
+        "banner_image_uri" => "",
+        "background_color" => "",
+        "website_link" => "",
+        "twitter_link" => "",
+        "discord_link" => "",
+        "merkle_root" => zero_merkle_root
+      }
+
+      creation = expect_ethscription_success(
+        create_input(
+          creator: alice,
+          to: alice,
+          data_uri: "data:," + collection_data.to_json
+        )
+      )
+
+      created_collection_id = creation[:ethscription_ids].first
+      initial_owner = CollectionsReader.get_collection_owner(created_collection_id)
+      expect(initial_owner.downcase).to eq(alice.downcase)
+
       transfer_data = {
         "p" => "erc-721-ethscriptions-collection",
         "op" => "transfer_ownership",
-        "collection_id" => collection_id,
+        "collection_id" => created_collection_id,
         "new_owner" => bob
       }
 
       expect_ethscription_success(
         create_input(
           creator: alice,
-          to: dummy_recipient,
+          to: alice,
           data_uri: "data:," + transfer_data.to_json
         )
       )
+
+      updated_owner = CollectionsReader.get_collection_owner(created_collection_id)
+      expect(updated_owner.downcase).to eq(bob.downcase)
+    end
+
+    it "keeps ownership unchanged when the collection leader ethscription transfers" do
+      collection_data = {
+        "p" => "erc-721-ethscriptions-collection",
+        "op" => "create_collection",
+        "name" => "Leader Transfer",
+        "symbol" => "LEAD",
+        "max_supply" => "5",
+        "description" => "",
+        "logo_image_uri" => "",
+        "banner_image_uri" => "",
+        "background_color" => "",
+        "website_link" => "",
+        "twitter_link" => "",
+        "discord_link" => "",
+        "merkle_root" => zero_merkle_root
+      }
+
+      creation = expect_ethscription_success(
+        create_input(
+          creator: alice,
+          to: alice,
+          data_uri: "data:," + collection_data.to_json
+        )
+      )
+
+      created_collection_id = creation[:ethscription_ids].first
+      expect(CollectionsReader.get_collection_owner(created_collection_id).downcase).to eq(alice.downcase)
+
+      expect_transfer_success(
+        transfer_input(from: alice, to: bob, id: created_collection_id),
+        created_collection_id,
+        bob
+      )
+
+      # Collection owner stays Alice despite the ethscription transfer
+      current_owner = CollectionsReader.get_collection_owner(created_collection_id)
+      expect(current_owner.downcase).to eq(alice.downcase)
+    end
+
+    it "renounces ownership even when locked" do
+      collection_data = {
+        "p" => "erc-721-ethscriptions-collection",
+        "op" => "create_collection",
+        "name" => "Renounce Test",
+        "symbol" => "REN",
+        "max_supply" => "25",
+        "description" => "",
+        "logo_image_uri" => "",
+        "banner_image_uri" => "",
+        "background_color" => "",
+        "website_link" => "",
+        "twitter_link" => "",
+        "discord_link" => "",
+        "merkle_root" => zero_merkle_root
+      }
+
+      creation = expect_ethscription_success(
+        create_input(
+          creator: alice,
+          to: alice,
+          data_uri: "data:," + collection_data.to_json
+        )
+      )
+
+      created_collection_id = creation[:ethscription_ids].first
+
+      lock_data = {
+        "p" => "erc-721-ethscriptions-collection",
+        "op" => "lock_collection",
+        "collection_id" => created_collection_id
+      }
+
+      expect_ethscription_success(
+        create_input(
+          creator: alice,
+          to: alice,
+          data_uri: "data:," + lock_data.to_json
+        )
+      )
+
+      renounce_data = {
+        "p" => "erc-721-ethscriptions-collection",
+        "op" => "renounce_ownership",
+        "collection_id" => created_collection_id
+      }
+
+      expect_ethscription_success(
+        create_input(
+          creator: alice,
+          to: alice,
+          data_uri: "data:," + renounce_data.to_json
+        )
+      )
+
+      owner_after_renounce = CollectionsReader.get_collection_owner(created_collection_id)
+      expect(owner_after_renounce.downcase).to eq('0x0000000000000000000000000000000000000000')
     end
 
     it "handles batch operations with arrays" do

--- a/spec/models/erc721_ethscriptions_collection_parser_spec.rb
+++ b/spec/models/erc721_ethscriptions_collection_parser_spec.rb
@@ -301,6 +301,35 @@ RSpec.describe Erc721EthscriptionsCollectionParser do
       end
     end
 
+    describe 'transfer_ownership operation' do
+      it 'encodes transfer_ownership with collection_id and new_owner' do
+        new_owner = '0x' + '1' * 40
+        json = %(data:,{"p":"erc-721-ethscriptions-collection","op":"transfer_ownership","collection_id":"0x#{"2" * 64}","new_owner":"#{new_owner}"})
+        result = ProtocolParser.for_calldata(json)
+
+        expect(result[0]).to eq('erc-721-ethscriptions-collection'.b)
+        expect(result[1]).to eq('transfer_ownership'.b)
+
+        decoded = Eth::Abi.decode(['(bytes32,address)'], result[2])[0]
+        expect(decoded[0].unpack1('H*')).to eq('2' * 64)
+        expect(decoded[1]).to eq(new_owner)
+      end
+    end
+
+    describe 'renounce_ownership operation' do
+      it 'encodes renounce_ownership as single bytes32' do
+        json = 'data:,{"p":"erc-721-ethscriptions-collection","op":"renounce_ownership","collection_id":"0x' + '3' * 64 + '"}'
+        result = ProtocolParser.for_calldata(json)
+
+        expect(result[0]).to eq('erc-721-ethscriptions-collection'.b)
+        expect(result[1]).to eq('renounce_ownership'.b)
+
+        # Eth::Abi.decode treats strings containing only hex characters as hex input,
+        # so compare the packed bytes directly via hex.
+        expect(result[2].unpack1('H*')).to eq('3' * 64)
+      end
+    end
+
     describe 'round-trip tests' do
       # @generic-compatible
       it 'preserves all data through encode/decode cycle' do
@@ -376,6 +405,12 @@ RSpec.describe Erc721EthscriptionsCollectionParser do
       it 'returns default params for missing required fields' do
         # Missing collection_id
         json = 'data:,{"p":"erc-721-ethscriptions-collection","op":"lock_collection"}'
+        result = ProtocolParser.for_calldata(json)
+        expect(result).to eq(default_params)
+      end
+
+      it 'rejects zero address for transfer_ownership new_owner' do
+        json = 'data:,{"p":"erc-721-ethscriptions-collection","op":"transfer_ownership","collection_id":"0x' + '4' * 64 + '","new_owner":"0x' + '0' * 40 + '"}'
         result = ProtocolParser.for_calldata(json)
         expect(result).to eq(default_params)
       end

--- a/spec/models/protocol_parser_spec.rb
+++ b/spec/models/protocol_parser_spec.rb
@@ -1,0 +1,155 @@
+require 'rails_helper'
+
+RSpec.describe ProtocolParser do
+  let(:zero_merkle_root) { '0x' + '0' * 64 }
+
+  describe '.extract' do
+    context 'word domains protocol' do
+      it 'parses raw word registrations' do
+        content_uri = 'data:,alpha'
+
+        result = described_class.extract(content_uri)
+
+        expect(result).not_to be_nil
+        expect(result[:type]).to eq(:word_domains)
+        expect(result[:protocol]).to eq('word-domains'.b)
+        expect(result[:operation]).to eq('register'.b)
+      end
+
+      it 'parses set_primary JSON operations' do
+        content_uri = 'data:,{"p":"word-domains","op":"set_primary","name":"alpha"}'
+
+        result = described_class.extract(content_uri)
+
+        expect(result).not_to be_nil
+        expect(result[:type]).to eq(:word_domains)
+        expect(result[:operation]).to eq('set_primary'.b)
+      end
+    end
+    context 'erc-20-fixed-denomination protocol' do
+      it 'parses a valid deploy inscription' do
+        content_uri = 'data:,{"p":"erc-20","op":"deploy","tick":"punk","max":"21000000","lim":"1000"}'
+
+        result = described_class.extract(content_uri)
+
+        expect(result).not_to be_nil
+        expect(result[:type]).to eq(:erc20_fixed_denomination)
+        expect(result[:protocol]).to eq('erc-20-fixed-denomination')
+        expect(result[:operation]).to eq('deploy'.b)
+      end
+
+      it 'parses a valid mint inscription' do
+        content_uri = 'data:,{"p":"erc-20","op":"mint","tick":"punk","id":"1","amt":"100"}'
+
+        result = described_class.extract(content_uri)
+
+        expect(result).not_to be_nil
+        expect(result[:type]).to eq(:erc20_fixed_denomination)
+        expect(result[:operation]).to eq('mint'.b)
+      end
+
+      it 'returns nil when the inscription is malformed' do
+        content_uri = 'data:,{"p":"erc-20","op":"mint","tick":"punk","amt":"100"}'
+
+        expect(described_class.extract(content_uri)).to be_nil
+      end
+    end
+
+    context 'erc-721 collections protocol' do
+      it 'parses a create_collection inscription' do
+        content_uri = %(data:,{"p":"erc-721-ethscriptions-collection","op":"create_collection","name":"My NFTs","symbol":"MNFT","max_supply":"100","description":"","logo_image_uri":"","banner_image_uri":"","background_color":"","website_link":"","twitter_link":"","discord_link":"","merkle_root":"#{zero_merkle_root}"})
+
+        result = described_class.extract(content_uri)
+
+        expect(result).not_to be_nil
+        expect(result[:type]).to eq(:erc721_ethscriptions_collection)
+        expect(result[:protocol]).to eq('erc-721-ethscriptions-collection'.b)
+        expect(result[:operation]).to eq('create_collection'.b)
+      end
+
+      it 'parses add_self_to_collection and succeeds with required fields' do
+        inscription_id = '0x' + '1' * 64
+        content_uri = 'data:,{"p":"erc-721-ethscriptions-collection","op":"add_self_to_collection","collection_id":"0x' + '2' * 64 + '","item":{"item_index":"0","name":"Item","background_color":"#000000","description":"","attributes":[],"merkle_proof":[]}}'
+
+        result = described_class.extract(content_uri, ethscription_id: inscription_id)
+
+        expect(result).not_to be_nil
+        expect(result[:type]).to eq(:erc721_ethscriptions_collection)
+        expect(result[:operation]).to eq('add_self_to_collection'.b)
+      end
+
+      it 'returns nil for non-collection JSON' do
+        expect(described_class.extract('data:,{"p":"foo","op":"bar"}')).to be_nil
+      end
+    end
+
+    context 'non-protocol data' do
+      it 'returns nil for text payloads' do
+        expect(described_class.extract('data:,Hello World')).to be_nil
+      end
+
+      it 'returns nil for invalid JSON' do
+        expect(described_class.extract('data:,{invalid json')).to be_nil
+      end
+
+      it 'returns nil for nil input' do
+        expect(described_class.extract(nil)).to be_nil
+      end
+    end
+  end
+
+  describe '.for_calldata' do
+    it 'encodes word domain registrations' do
+      protocol, operation, encoded = described_class.for_calldata('data:,beta')
+
+      expect(protocol).to eq('word-domains'.b)
+      expect(operation).to eq('register'.b)
+      expect(Eth::Abi.decode(['string'], encoded).first).to eq('beta')
+    end
+
+    it 'encodes word domain set_primary operations' do
+      content_uri = 'data:,{"p":"word-domains","op":"set_primary","name":"beta"}'
+
+      protocol, operation, encoded = described_class.for_calldata(content_uri)
+
+      expect(protocol).to eq('word-domains'.b)
+      expect(operation).to eq('set_primary'.b)
+      expect(Eth::Abi.decode(['string'], encoded).first).to eq('beta')
+    end
+    it 'encodes erc-20 deploy params' do
+      content_uri = 'data:,{"p":"erc-20","op":"deploy","tick":"punk","max":"21000000","lim":"1000"}'
+
+      protocol, operation, encoded = described_class.for_calldata(content_uri)
+
+      expect(protocol).to eq('erc-20-fixed-denomination'.b)
+      expect(operation).to eq('deploy'.b)
+      decoded = Eth::Abi.decode(['(string,uint256,uint256)'], encoded)[0]
+      expect(decoded).to eq(['punk'.b, 21_000_000, 1000])
+    end
+
+    it 'encodes erc-20 mint params' do
+      content_uri = 'data:,{"p":"erc-20","op":"mint","tick":"punk","id":"1","amt":"100"}'
+
+      protocol, operation, encoded = described_class.for_calldata(content_uri)
+
+      expect(protocol).to eq('erc-20-fixed-denomination'.b)
+      expect(operation).to eq('mint'.b)
+      decoded = Eth::Abi.decode(['(string,uint256,uint256)'], encoded)[0]
+      expect(decoded).to eq(['punk'.b, 1, 100])
+    end
+
+    it 'returns encoded data for collections protocol' do
+      content_uri = %(data:,{"p":"erc-721-ethscriptions-collection","op":"create_collection","name":"My NFTs","symbol":"MNFT","max_supply":"42","description":"","logo_image_uri":"","banner_image_uri":"","background_color":"","website_link":"","twitter_link":"","discord_link":"","merkle_root":"#{zero_merkle_root}"})
+
+      protocol, operation, encoded = described_class.for_calldata(content_uri)
+
+      expect(protocol).to eq('erc-721-ethscriptions-collection'.b)
+      expect(operation).to eq('create_collection'.b)
+      expect(encoded).not_to be_empty
+    end
+
+    it 'returns empty protocol params when nothing matches' do
+      expect(described_class.for_calldata('data:,Hello World')).to eq([''.b, ''.b, ''.b])
+    end
+  end
+end


### PR DESCRIPTION
- Updated `ERC721EthscriptionsCollection` to return Base64-encoded JSON for metadata.
- Refactored `NameRegistry` to include a new `contractURI` method for OpenSea collection-level metadata.
- Implemented transfer and approval functions to revert transfers, enhancing security.
- Updated tests to validate the new Base64 encoding and ensure correct URI handling.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds collection ownership transfer/renounce operations, serves Base64-encoded metadata (with URI resolution), refactors NameRegistry metadata and transfer blocking, and updates parser/tests accordingly.
> 
> - **Collections Protocol (contracts & parser)**:
>   - **Ownership Management**: Add `transfer_ownership` and `renounce_ownership` ops, `_transferCollectionOwnership`, and `OwnershipTransferred` event in `ERC721EthscriptionsCollectionManager`; remove implicit owner change on leader ethscription transfer.
>   - **Parser**: Support new ops with strict validation (`address`, non-zero), value builders, and encoding paths.
> - **Metadata**:
>   - **Collection**: `ERC721EthscriptionsCollection.contractURI()` now returns Base64-encoded JSON and resolves `esc://ethscriptions/{id}/data`; `tokenURI` uses raw `mediaUri`.
>   - **NameRegistry**: Base64-encoded `tokenURI`, new `contractURI()`, escaped JSON fields, and `protocolName` constant.
> - **Transfer Restrictions**:
>   - Explicitly revert all ERC-721 transfer/approval methods in `ERC721EthscriptionsCollection` and `NameRegistry`.
> - **Tests**:
>   - Add URI resolution tests (including Base64 decode and `esc://` handling).
>   - Integration tests for Merkle root enforcement, ownership transfer/renounce behavior, and parser round-trips.
>   - New `ProtocolParser` specs and expanded collection parser specs for new ops/validation.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 64230aec9e0dab69b0c6eb6b51d5162e5d8a0587. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->