### PR TITLE
Update Address Validation and Metadata Descriptions in Contracts

### DIFF
--- a/app/models/erc721_ethscriptions_collection_parser.rb
+++ b/app/models/erc721_ethscriptions_collection_parser.rb
@@ -508,7 +508,7 @@ class Erc721EthscriptionsCollectionParser
   end
 
   def validate_address(value, field_name)
-    unless value.is_a?(String) && value.match?(/\A0x[0-9a-f]{40}\z/)
+    unless value.is_a?(String) && value.match?(/\A0x[0-9a-f]{40}\z/i)
       raise ValidationError, "Invalid address for #{field_name}: #{value}"
     end
 

--- a/contracts/src/NameRegistry.sol
+++ b/contracts/src/NameRegistry.sol
@@ -197,7 +197,7 @@ contract NameRegistry is ERC721EthscriptionsEnumerableUpgradeable, IProtocolHand
         bytes memory json = abi.encodePacked(
             '{"name":"',
             name.escapeJSON(),
-            '","description":"Dotless word domain"',
+            '","description":"An Ethscriptions name"',
             ',"ethscription_id":"',
             ethscriptionIdHex,
             '","ethscription_number":',
@@ -207,9 +207,9 @@ contract NameRegistry is ERC721EthscriptionsEnumerableUpgradeable, IProtocolHand
             '":"',
             mediaUri,
             '","attributes":[',
-            '{"trait_type":"Name","value":"',
-            name.escapeJSON(),
-            '"}',
+            '{"trait_type":"Length","value":',
+            bytes(name).length.toString(),
+            ',"display_type":"number"}',
             ']}'
         );
 
@@ -223,7 +223,7 @@ contract NameRegistry is ERC721EthscriptionsEnumerableUpgradeable, IProtocolHand
             'data:application/json;base64,',
             Base64.encode(bytes(
                 '{"name":"Word Domains Registry",'
-                '"description":"On-chain word domain name system for Ethscriptions. Register unique, dotless domain names as NFTs.",'
+                '"description":"On-chain name system for Ethscriptions. Allowed characters: a-z, 0-9, and _ (underscore). Max length: 30 characters.",'
                 '"image":"data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iNTAwIiBoZWlnaHQ9IjUwMCIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj48cmVjdCB3aWR0aD0iNTAwIiBoZWlnaHQ9IjUwMCIgZmlsbD0iIzEwMTAxMCIvPjx0ZXh0IHg9IjI1MCIgeT0iMjUwIiBmb250LXNpemU9IjgwIiBmb250LWZhbWlseT0ibW9ub3NwYWNlIiB0ZXh0LWFuY2hvcj0ibWlkZGxlIiBmaWxsPSIjMDBmZjAwIj5bTkFNRVNdPC90ZXh0Pjwvc3ZnPg==",'
                 '"external_link":"https://ethscriptions.com"}'
             ))


### PR DESCRIPTION
- Modified the address validation method in `Erc721EthscriptionsCollectionParser` to be case-insensitive for Ethereum addresses.
- Updated the description in the `NameRegistry` contract to clarify the purpose of the Ethscriptions name and allowed characters.
- Enhanced metadata attributes to include the length of the name, improving the representation of domain characteristics.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Makes Ethereum address validation case-insensitive and revises NameRegistry token/collection metadata (description and attributes).
> 
> - **Parser (`app/models/erc721_ethscriptions_collection_parser.rb`)**:
>   - Address validation `validate_address` now accepts mixed-case hex via case-insensitive regex (`/i`), still normalizing to lowercase.
> - **Contracts (`contracts/src/NameRegistry.sol`)**:
>   - Token metadata (`tokenURI`):
>     - Update description to "An Ethscriptions name".
>     - Replace `Name` attribute with numeric `Length` attribute (`display_type: number`).
>   - Collection metadata (`contractURI`):
>     - Update description to specify allowed characters and max length.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 423fd7cabd2b4f30676f654263bb854058f28969. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->